### PR TITLE
[FEAT] API 공통 응답 및 에러 포맷 통일

### DIFF
--- a/src/main/java/com/lxp/aplus/APlusApplication.java
+++ b/src/main/java/com/lxp/aplus/APlusApplication.java
@@ -2,7 +2,9 @@ package com.lxp.aplus;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class APlusApplication {
 

--- a/src/main/java/com/lxp/aplus/common/error/BusinessException.java
+++ b/src/main/java/com/lxp/aplus/common/error/BusinessException.java
@@ -1,0 +1,13 @@
+package com.lxp.aplus.common.error;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/lxp/aplus/common/error/ErrorCode.java
+++ b/src/main/java/com/lxp/aplus/common/error/ErrorCode.java
@@ -1,0 +1,16 @@
+package com.lxp.aplus.common.error;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * 에러 코드에 대한 Enum class
+ * 에러 코드 형식
+ * 1. 모든 에러 코드는 "E"로 시작한다.
+ * 2. 2번째 문자는 에러가 발생한 카테고리를 나타낸다.
+ * ex) "U": User, "A": Article, "C": Collection, "F": File
+ */
+public interface ErrorCode {
+    HttpStatus getStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/com/lxp/aplus/common/error/ErrorResponse.java
+++ b/src/main/java/com/lxp/aplus/common/error/ErrorResponse.java
@@ -1,0 +1,20 @@
+package com.lxp.aplus.common.error;
+
+import lombok.Builder;
+import org.springframework.http.HttpStatus;
+
+@Builder
+public record ErrorResponse(
+        HttpStatus status,
+        String code,
+        String message
+) {
+
+    public static ErrorResponse from(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .status(errorCode.getStatus())
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .build();
+    }
+}

--- a/src/main/java/com/lxp/aplus/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/lxp/aplus/common/error/GlobalExceptionHandler.java
@@ -1,0 +1,83 @@
+package com.lxp.aplus.common.error;
+
+import com.lxp.aplus.common.error.code.GlobalErrorCode;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 1. 비즈니스 예외 처리
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        log.warn("Business Exception : [Code: {}] {}", e.getErrorCode().getCode(), e.getErrorCode().getMessage());
+        return makeErrorResponse(e.getErrorCode());
+    }
+
+    // 2. DTO 검증 오류 처리 (@Valid)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(fieldError -> fieldError.getField() + " : " + fieldError.getDefaultMessage())
+                .orElse(GlobalErrorCode.VALIDATION_ERROR.getMessage());
+
+        log.warn("Validation Exception : {}", message);
+        return makeErrorResponse(GlobalErrorCode.VALIDATION_ERROR, message);
+    }
+
+    // 3. PathVariable / RequestParam 검증 실패 처리 (@Validated)
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolation(ConstraintViolationException e) {
+        String message = e.getConstraintViolations().stream()
+                .findFirst()
+                .map(v -> v.getPropertyPath() + " : " + v.getMessage())
+                .orElse(GlobalErrorCode.VALIDATION_ERROR.getMessage());
+
+        log.warn("Constraint Violation : {}", message);
+        return makeErrorResponse(GlobalErrorCode.VALIDATION_ERROR, message);
+    }
+
+    // 4. JSON 파싱 오류 처리
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleJsonParseError(HttpMessageNotReadableException e) {
+        log.warn("JSON Parse Error : {}", e.getMessage());
+        return makeErrorResponse(GlobalErrorCode.INVALID_JSON);
+    }
+
+    // 5. 필수 요청 파라미터 누락 처리
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingParameter(MissingServletRequestParameterException e) {
+        String message = e.getParameterName() + " 파라미터가 필요합니다.";
+        log.warn("Missing Parameter : {}", message);
+        return makeErrorResponse(GlobalErrorCode.MISSING_PARAMETER, message);
+    }
+
+    // 6. 예상치 못한 서버 오류 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnexpectedException(Exception e) {
+        log.error("Unexpected Error Occurred : ", e);
+        return makeErrorResponse(GlobalErrorCode.INTERNAL_ERROR);
+    }
+
+    private ResponseEntity<ErrorResponse> makeErrorResponse(ErrorCode errorCode) {
+        return makeErrorResponse(errorCode, errorCode.getMessage());
+    }
+
+    private ResponseEntity<ErrorResponse> makeErrorResponse(ErrorCode errorCode, String message) {
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ErrorResponse.builder()
+                        .status(errorCode.getStatus())
+                        .code(errorCode.getCode())
+                        .message(message)
+                        .build());
+    }
+}

--- a/src/main/java/com/lxp/aplus/common/error/code/CourseErrorCode.java
+++ b/src/main/java/com/lxp/aplus/common/error/code/CourseErrorCode.java
@@ -1,0 +1,16 @@
+package com.lxp.aplus.common.error.code;
+
+import com.lxp.aplus.common.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CourseErrorCode implements ErrorCode {
+    COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "EC001", "해당 강의를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/lxp/aplus/common/error/code/GlobalErrorCode.java
+++ b/src/main/java/com/lxp/aplus/common/error/code/GlobalErrorCode.java
@@ -1,0 +1,19 @@
+package com.lxp.aplus.common.error.code;
+
+import com.lxp.aplus.common.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalErrorCode implements ErrorCode {
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "EG001", "잘못된 요청입니다."),
+    INVALID_JSON(HttpStatus.BAD_REQUEST, "EG002", "요청 본문을 읽을 수 없습니다. JSON 형식을 확인해주세요."),
+    MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "EG003", "필수 요청 파라미터가 누락되었습니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "EG004", "예기치 못한 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/lxp/aplus/common/result/ResultCode.java
+++ b/src/main/java/com/lxp/aplus/common/result/ResultCode.java
@@ -1,0 +1,17 @@
+package com.lxp.aplus.common.result;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * 결과 코드에 대한 Enum class
+ * 결과 코드 형식
+ * 1. 모든 결과 코드는 "S"로 시작한다.
+ * 2. 2번째 문자는 결과가 발생한 카테고리를 나타낸다.
+ * ex) "M": Member, "SP": SalePost, "B": Book, "R": Report
+ *
+ */
+public interface ResultCode {
+    HttpStatus getStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/com/lxp/aplus/common/result/ResultResponse.java
+++ b/src/main/java/com/lxp/aplus/common/result/ResultResponse.java
@@ -1,0 +1,30 @@
+package com.lxp.aplus.common.result;
+
+import lombok.Builder;
+import org.springframework.http.HttpStatus;
+
+@Builder
+public record ResultResponse<T>(
+        HttpStatus status,
+        String code,
+        String message,
+        T data
+) {
+    public static <T> ResultResponse<T> of(ResultCode resultCode, T data) {
+        return ResultResponse.<T>builder()
+                .status(resultCode.getStatus())
+                .code(resultCode.getCode())
+                .message(resultCode.getMessage())
+                .data(data)
+                .build();
+    }
+
+    public static <T> ResultResponse<T> from(ResultCode resultCode) {
+        return ResultResponse.<T>builder()
+                .status(resultCode.getStatus())
+                .code(resultCode.getCode())
+                .message(resultCode.getMessage())
+                .data(null)
+                .build();
+    }
+}

--- a/src/main/java/com/lxp/aplus/common/result/code/CourseResultCode.java
+++ b/src/main/java/com/lxp/aplus/common/result/code/CourseResultCode.java
@@ -1,0 +1,16 @@
+package com.lxp.aplus.common.result.code;
+
+import com.lxp.aplus.common.result.ResultCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CourseResultCode implements ResultCode {
+    COURSE_REGISTER_SUCCESS(HttpStatus.CREATED, "SC001", "강의가 정상적으로 등록되었습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}


### PR DESCRIPTION
<!-- PR 제목 : [FEAT] API 공통 응답 및 에러 포맷 통일 -->

## ✨ 요약
- API 응답 구조를 공통화하여 일관된 JSON 포맷 제공
- 성공 응답: `ResultResponse`
- 에러 응답: `ErrorResponse`

## 📝 작업 내용
- `ResultResponse` 및 `ErrorResponse` 클래스 구현
- 에러 처리 시 공통 예외 핸들러 적용

## 💭 주의 사항

## 💡 리뷰 포인트
- 공통 응답 구조 적용이 올바르게 되었는지
- 예외 핸들러 적용 범위가 적절한지
- 로깅 작업이 적절하게 반영되었는지

## ✅ 테스트
- [x] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [ ] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
