### PR TITLE
[FEAT] 수강(Enrollment) 도메인 구현

### DIFF
--- a/src/main/java/com/lxp/aplus/common/error/code/EnrollmentErrorCode.java
+++ b/src/main/java/com/lxp/aplus/common/error/code/EnrollmentErrorCode.java
@@ -1,0 +1,30 @@
+package com.lxp.aplus.common.error.code;
+
+import com.lxp.aplus.common.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum EnrollmentErrorCode implements ErrorCode {
+    ALREADY_ENROLLED_COURSE(HttpStatus.CONFLICT, "EE001", "이미 수강 중인 강의가 포함되어 있습니다."),
+    ENROLLMENT_COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "EE002", "존재하지 않는 강의가 포함되어 있습니다."),
+    INVALID_ENROLLMENT_STATUS(HttpStatus.BAD_REQUEST, "EE003", "지원하지 않는 수강 상태(status) 값입니다."),
+    ENROLLMENT_NOT_FOUND_OR_NO_ACCESS(HttpStatus.NOT_FOUND, "EE004", "해당 수강 내역을 찾을 수 없거나 접근 권한이 없습니다."),
+    ENROLLMENT_TO_CANCEL_NOT_FOUND(HttpStatus.NOT_FOUND, "EE005", "취소할 수강 내역이 존재하지 않습니다."),
+    CANNOT_CANCEL_COMPLETED_ENROLLMENT(HttpStatus.CONFLICT, "EE006", "이미 수강이 완료(수료)되어 취소할 수 없습니다."),
+    CANNOT_CANCEL_EXPIRED_ENROLLMENT(HttpStatus.CONFLICT, "EE007", "수강 기간이 만료되어 취소할 수 없습니다."),
+    ALREADY_CANCELLED_ENROLLMENT(HttpStatus.CONFLICT, "EE008", "이미 취소 처리된 건입니다."),
+    ENROLLMENT_EXPIRED_HISTORY_ACCESS_DENIED(HttpStatus.BAD_REQUEST, "EE009", "수강 기간이 만료되어 학습 이력을 조회할 수 없습니다."),
+    CANNOT_UPDATE_PROGRESS_FOR_NON_ENROLLED(HttpStatus.BAD_REQUEST, "EE010", "수강 중인 강의만 진도율을 업데이트할 수 있습니다."),
+
+    LEARNING_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "EP001", "학습 이력이 존재하지 않습니다."),
+    INVALID_PROGRESS_RATE(HttpStatus.BAD_REQUEST, "EP002", "진도율은 0에서 100 사이의 값이어야 합니다."),
+    WATCHED_DURATION_EXCEEDS_TOTAL(HttpStatus.BAD_REQUEST, "EP003", "시청 시간이 전체 영상 길이를 초과할 수 없습니다."),
+    ENROLLMENT_EXPIRED_PROGRESS_UPDATE_DENIED(HttpStatus.CONFLICT, "EP004", "수강 기간이 만료되어 진도율을 갱신할 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/lxp/aplus/common/error/code/GlobalErrorCode.java
+++ b/src/main/java/com/lxp/aplus/common/error/code/GlobalErrorCode.java
@@ -11,7 +11,8 @@ public enum GlobalErrorCode implements ErrorCode {
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "EG001", "잘못된 요청입니다."),
     INVALID_JSON(HttpStatus.BAD_REQUEST, "EG002", "요청 본문을 읽을 수 없습니다. JSON 형식을 확인해주세요."),
     MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "EG003", "필수 요청 파라미터가 누락되었습니다."),
-    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "EG004", "예기치 못한 오류가 발생했습니다.");
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "EG004", "예기치 못한 오류가 발생했습니다."),
+    INVALID_ARGUMENT(HttpStatus.BAD_REQUEST, "EG005", "유효하지 않은 인자값입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/lxp/aplus/common/result/code/EnrollmentResultCode.java
+++ b/src/main/java/com/lxp/aplus/common/result/code/EnrollmentResultCode.java
@@ -1,0 +1,23 @@
+package com.lxp.aplus.common.result.code;
+
+import com.lxp.aplus.common.result.ResultCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum EnrollmentResultCode implements ResultCode {
+    ENROLLMENT_SUCCESS(HttpStatus.CREATED, "SE001", "결제 검증 및 수강 신청이 정상적으로 완료되었습니다."),
+    GET_ENROLLMENTS_SUCCESS(HttpStatus.OK, "SE002", "수강 목록 조회에 성공하였습니다."),
+    GET_ENROLLMENT_DETAIL_SUCCESS(HttpStatus.OK, "SE003", "수강 상세 정보 조회에 성공하였습니다."),
+
+    UPDATE_PROGRESS_SUCCESS(HttpStatus.OK, "SP001", "진도율이 갱신되었습니다."),
+    GET_PROGRESS_SUCCESS(HttpStatus.OK, "SP002", "학습 이력을 조회하였습니다."),
+    CANCEL_ENROLLMENT_SUCCESS(HttpStatus.OK, "SE003", "수강이 정상적으로 취소되었습니다.");
+
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/lxp/aplus/enrollment/domain/Enrollment.java
+++ b/src/main/java/com/lxp/aplus/enrollment/domain/Enrollment.java
@@ -1,14 +1,14 @@
 package com.lxp.aplus.enrollment.domain;
 
-import com.lxp.aplus.common.domain.BaseTimeEntity;
+import com.lxp.aplus.common.error.BusinessException;
+import com.lxp.aplus.common.error.code.EnrollmentErrorCode;
+import com.lxp.aplus.common.domain.BaseAggregateRoot;
+import com.lxp.aplus.common.error.code.GlobalErrorCode;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.springframework.util.Assert;
+import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Entity
 @Table(name = "enrollments",
@@ -20,8 +20,13 @@ import java.time.LocalDateTime;
         }
 )
 @Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Enrollment extends BaseTimeEntity {
+public class Enrollment extends BaseAggregateRoot {
+
+    private static final int MIN_PROGRESS_RATE = 0;
+    private static final int MAX_PROGRESS_RATE = 100;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,63 +39,61 @@ public class Enrollment extends BaseTimeEntity {
     private Long courseId;
 
     @Enumerated(EnumType.STRING)
-    private EnrollmentStatus status;
+    @Builder.Default
+    private EnrollmentStatus status = EnrollmentStatus.ENROLLED;
 
     @Column(nullable = false)
-    private Integer progressRate;
+    @Builder.Default
+    private int progressRate = MIN_PROGRESS_RATE;
 
     @Column(nullable = false)
     private LocalDateTime expiredAt;
 
-    @Builder(access = AccessLevel.PRIVATE)
-    private Enrollment(Long studentId, Long courseId, EnrollmentStatus status, Integer progressRate, LocalDateTime expiredAt) {
-        Assert.notNull(studentId, "studentId는 null일 수 없습니다.");
-        Assert.notNull(courseId, "courseId는 null일 수 없습니다.");
-        Assert.notNull(status, "status는 null일 수 없습니다.");
-
-        this.studentId = studentId;
-        this.courseId = courseId;
-        this.status = status;
-        this.progressRate = progressRate;
-        this.expiredAt = expiredAt;
-    }
-
-    public static Enrollment enroll(Long studentId, Long courseId, LocalDateTime expiredAt) {
-        Assert.notNull(expiredAt, "expiredAt은 null일 수 없습니다.");
+    public static Enrollment of(Long studentId, Long courseId, LocalDateTime expiredAt) {
+        if (Objects.isNull(studentId) || Objects.isNull(courseId) || Objects.isNull(expiredAt)) {
+            throw new BusinessException(GlobalErrorCode.INVALID_ARGUMENT);
+        }
 
         return Enrollment.builder()
                 .studentId(studentId)
                 .courseId(courseId)
-                .status(EnrollmentStatus.ENROLLED)
-                .progressRate(0)
                 .expiredAt(expiredAt)
                 .build();
     }
 
     public void cancel() {
         if (this.status == EnrollmentStatus.COMPLETED) {
-            throw new IllegalStateException("이미 수료한 강의는 취소할 수 없습니다.");
+            throw new BusinessException(EnrollmentErrorCode.CANNOT_CANCEL_COMPLETED_ENROLLMENT);
+        }
+        if (this.status == EnrollmentStatus.CANCELED) {
+            throw new BusinessException(EnrollmentErrorCode.ALREADY_CANCELLED_ENROLLMENT);
+        }
+        if (isExpired()) {
+            throw new BusinessException(EnrollmentErrorCode.CANNOT_CANCEL_EXPIRED_ENROLLMENT);
         }
         this.status = EnrollmentStatus.CANCELED;
     }
 
     public void updateProgress(int newProgressRate) {
         if (this.status != EnrollmentStatus.ENROLLED) {
-            throw new IllegalStateException("수강 중인 강의만 진도율을 업데이트할 수 있습니다.");
+            throw new BusinessException(EnrollmentErrorCode.CANNOT_UPDATE_PROGRESS_FOR_NON_ENROLLED);
         }
-        if (newProgressRate < 0 || newProgressRate > 100) {
-            throw new IllegalArgumentException("진도율은 0~100 사이여야 합니다.");
+        if (isExpired()) {
+            throw new BusinessException(EnrollmentErrorCode.ENROLLMENT_EXPIRED_PROGRESS_UPDATE_DENIED);
+        }
+        if (newProgressRate < MIN_PROGRESS_RATE || newProgressRate > MAX_PROGRESS_RATE) {
+            throw new BusinessException(EnrollmentErrorCode.INVALID_PROGRESS_RATE);
         }
 
         this.progressRate = newProgressRate;
 
-        if (this.progressRate == 100) {
+        if (this.progressRate == MAX_PROGRESS_RATE) {
             this.complete();
         }
     }
 
-    public void complete() {
-        this.progressRate = 100;
+    private void complete() {
+        this.progressRate = MAX_PROGRESS_RATE;
         this.status = EnrollmentStatus.COMPLETED;
     }
 

--- a/src/main/java/com/lxp/aplus/enrollment/domain/Enrollment.java
+++ b/src/main/java/com/lxp/aplus/enrollment/domain/Enrollment.java
@@ -1,0 +1,100 @@
+package com.lxp.aplus.enrollment.domain;
+
+import com.lxp.aplus.common.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "enrollments",
+        uniqueConstraints = {
+        @UniqueConstraint(
+                name = "uk_enrollment_student_course",
+                columnNames = {"studentId", "courseId"}
+            )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Enrollment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long studentId;
+
+    @Column(nullable = false)
+    private Long courseId;
+
+    @Enumerated(EnumType.STRING)
+    private EnrollmentStatus status;
+
+    @Column(nullable = false)
+    private Integer progressRate;
+
+    @Column(nullable = false)
+    private LocalDateTime expiredAt;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Enrollment(Long studentId, Long courseId, EnrollmentStatus status, Integer progressRate, LocalDateTime expiredAt) {
+        Assert.notNull(studentId, "studentId는 null일 수 없습니다.");
+        Assert.notNull(courseId, "courseId는 null일 수 없습니다.");
+        Assert.notNull(status, "status는 null일 수 없습니다.");
+
+        this.studentId = studentId;
+        this.courseId = courseId;
+        this.status = status;
+        this.progressRate = progressRate;
+        this.expiredAt = expiredAt;
+    }
+
+    public static Enrollment enroll(Long studentId, Long courseId, LocalDateTime expiredAt) {
+        Assert.notNull(expiredAt, "expiredAt은 null일 수 없습니다.");
+
+        return Enrollment.builder()
+                .studentId(studentId)
+                .courseId(courseId)
+                .status(EnrollmentStatus.ENROLLED)
+                .progressRate(0)
+                .expiredAt(expiredAt)
+                .build();
+    }
+
+    public void cancel() {
+        if (this.status == EnrollmentStatus.COMPLETED) {
+            throw new IllegalStateException("이미 수료한 강의는 취소할 수 없습니다.");
+        }
+        this.status = EnrollmentStatus.CANCELED;
+    }
+
+    public void updateProgress(int newProgressRate) {
+        if (this.status != EnrollmentStatus.ENROLLED) {
+            throw new IllegalStateException("수강 중인 강의만 진도율을 업데이트할 수 있습니다.");
+        }
+        if (newProgressRate < 0 || newProgressRate > 100) {
+            throw new IllegalArgumentException("진도율은 0~100 사이여야 합니다.");
+        }
+
+        this.progressRate = newProgressRate;
+
+        if (this.progressRate == 100) {
+            this.complete();
+        }
+    }
+
+    public void complete() {
+        this.progressRate = 100;
+        this.status = EnrollmentStatus.COMPLETED;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(this.expiredAt);
+    }
+}

--- a/src/main/java/com/lxp/aplus/enrollment/domain/EnrollmentRepository.java
+++ b/src/main/java/com/lxp/aplus/enrollment/domain/EnrollmentRepository.java
@@ -1,0 +1,14 @@
+package com.lxp.aplus.enrollment.domain;
+
+import java.util.Optional;
+
+public interface EnrollmentRepository {
+
+    Enrollment save(Enrollment enrollment);
+
+    Optional<Enrollment> findById(Long id);
+
+    boolean existsByStudentIdAndCourseId(Long studentId, Long courseId);
+
+    Optional<Enrollment> findByStudentIdAndCourseId(Long studentId, Long courseId);
+}

--- a/src/main/java/com/lxp/aplus/enrollment/domain/EnrollmentStatus.java
+++ b/src/main/java/com/lxp/aplus/enrollment/domain/EnrollmentStatus.java
@@ -1,0 +1,19 @@
+package com.lxp.aplus.enrollment.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum EnrollmentStatus {
+    ENROLLED("수강 중"),
+    COMPLETED("수강 완료"),
+    CANCELED("수강 취소"),
+    EXPIRED("수강 기간 만료");
+
+    private final String description;
+
+    public boolean isActive() {
+        return this == ENROLLED || this == COMPLETED;
+    }
+}

--- a/src/main/java/com/lxp/aplus/enrollment/domain/EnrollmentStatus.java
+++ b/src/main/java/com/lxp/aplus/enrollment/domain/EnrollmentStatus.java
@@ -3,7 +3,6 @@ package com.lxp.aplus.enrollment.domain;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-@Getter
 @RequiredArgsConstructor
 public enum EnrollmentStatus {
     ENROLLED("수강 중"),
@@ -11,6 +10,7 @@ public enum EnrollmentStatus {
     CANCELED("수강 취소"),
     EXPIRED("수강 기간 만료");
 
+    @Getter
     private final String description;
 
     public boolean isActive() {

--- a/src/test/java/com/lxp/aplus/enrollment/domain/EnrollmentTest.java
+++ b/src/test/java/com/lxp/aplus/enrollment/domain/EnrollmentTest.java
@@ -1,0 +1,69 @@
+package com.lxp.aplus.enrollment.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.*;
+
+class EnrollmentTest {
+
+    @Test
+    @DisplayName("수강 신청 시 초기 상태는 ENROLLED이며 진도율은 0이다.")
+    void enroll() {
+        // given
+        Long studentId = 1L;
+        Long courseId = 100L;
+        LocalDateTime expiredAt = LocalDateTime.now().plusYears(1);
+
+        // when
+        Enrollment enrollment = Enrollment.enroll(studentId, courseId, expiredAt);
+
+        // then
+        assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.ENROLLED);
+        assertThat(enrollment.getProgressRate()).isEqualTo(0);
+        assertThat(enrollment.getExpiredAt()).isEqualTo(expiredAt);
+    }
+
+    @Test
+    @DisplayName("진도율이 100%가 되면 자동으로 수료(COMPLETED) 상태로 변경된다.")
+    void updateProgress_complete() {
+        // given
+        Enrollment enrollment = Enrollment.enroll(1L, 100L, LocalDateTime.now().plusYears(1));
+
+        // when
+        enrollment.updateProgress(100);
+
+        // then
+        assertThat(enrollment.getProgressRate()).isEqualTo(100);
+        assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.COMPLETED);
+    }
+
+    @Test
+    @DisplayName("이미 수료한 강의는 취소할 수 없다.")
+    void cancel_fail_if_completed() {
+        // given
+        Enrollment enrollment = Enrollment.enroll(1L, 100L, LocalDateTime.now().plusYears(1));
+        enrollment.complete();
+
+        // when & then
+        assertThatThrownBy(enrollment::cancel)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("이미 수료한 강의는 취소할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("수강 기간이 지났는지 확인한다.")
+    void isExpired() {
+        // given: 어제 날짜로 만료일 설정
+        LocalDateTime pastDate = LocalDateTime.now().minusDays(1);
+        Enrollment enrollment = Enrollment.enroll(1L, 100L, pastDate);
+
+        // when
+        boolean expired = enrollment.isExpired();
+
+        // then
+        assertThat(expired).isTrue();
+    }
+}

--- a/src/test/java/com/lxp/aplus/enrollment/domain/EnrollmentTest.java
+++ b/src/test/java/com/lxp/aplus/enrollment/domain/EnrollmentTest.java
@@ -14,16 +14,20 @@ import static org.assertj.core.api.Assertions.*;
 
 class EnrollmentTest {
 
+    private static final Long STUDENT_ID = 1L;
+    private static final Long COURSE_ID = 100L;
+    private static final int MAX_PROGRESS_RATE = 100;
+    private static final int VALID_PROGRESS_RATE = 50;
+
+
     @Test
     @DisplayName("수강 신청 시 초기 상태는 ENROLLED이며 진도율은 0이다.")
     void enroll() {
         // given
-        Long studentId = 1L;
-        Long courseId = 100L;
         LocalDateTime expiredAt = LocalDateTime.now().plusYears(1);
 
         // when
-        Enrollment enrollment = Enrollment.of(studentId, courseId, expiredAt);
+        Enrollment enrollment = Enrollment.of(STUDENT_ID, COURSE_ID, expiredAt);
 
         // then
         assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.ENROLLED);
@@ -35,20 +39,18 @@ class EnrollmentTest {
     @DisplayName("of 정적 팩토리 메서드는 인자가 null이면 BusinessException을 던진다.")
     void of_fail_if_argument_is_null() {
         // given
-        Long studentId = 1L;
-        Long courseId = 100L;
         LocalDateTime expiredAt = LocalDateTime.now().plusYears(1);
 
         // when & then
-        assertThatThrownBy(() -> Enrollment.of(null, courseId, expiredAt))
+        assertThatThrownBy(() -> Enrollment.of(null, COURSE_ID, expiredAt))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", GlobalErrorCode.INVALID_ARGUMENT);
 
-        assertThatThrownBy(() -> Enrollment.of(studentId, null, expiredAt))
+        assertThatThrownBy(() -> Enrollment.of(STUDENT_ID, null, expiredAt))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", GlobalErrorCode.INVALID_ARGUMENT);
 
-        assertThatThrownBy(() -> Enrollment.of(studentId, courseId, null))
+        assertThatThrownBy(() -> Enrollment.of(STUDENT_ID, COURSE_ID, null))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", GlobalErrorCode.INVALID_ARGUMENT);
     }
@@ -57,13 +59,13 @@ class EnrollmentTest {
     @DisplayName("진도율이 100%가 되면 자동으로 수료(COMPLETED) 상태로 변경된다.")
     void updateProgress_complete() {
         // given
-        Enrollment enrollment = Enrollment.of(1L, 100L, LocalDateTime.now().plusYears(1));
+        Enrollment enrollment = Enrollment.of(STUDENT_ID, COURSE_ID, LocalDateTime.now().plusYears(1));
 
         // when
-        enrollment.updateProgress(100);
+        enrollment.updateProgress(MAX_PROGRESS_RATE);
 
         // then
-        assertThat(enrollment.getProgressRate()).isEqualTo(100);
+        assertThat(enrollment.getProgressRate()).isEqualTo(MAX_PROGRESS_RATE);
         assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.COMPLETED);
     }
 
@@ -72,7 +74,7 @@ class EnrollmentTest {
     @ValueSource(ints = {-1, 101})
     void updateProgress_fail_if_invalid_rate(int invalidProgressRate) {
         // given
-        Enrollment enrollment = Enrollment.of(1L, 100L, LocalDateTime.now().plusYears(1));
+        Enrollment enrollment = Enrollment.of(STUDENT_ID, COURSE_ID, LocalDateTime.now().plusYears(1));
 
         // when & then
         assertThatThrownBy(() -> enrollment.updateProgress(invalidProgressRate))
@@ -84,11 +86,11 @@ class EnrollmentTest {
     @DisplayName("수강 중이 아닌 강의의 진도율 업데이트 시 BusinessException을 던진다.")
     void updateProgress_fail_if_not_enrolled() {
         // given
-        Enrollment enrollment = Enrollment.of(1L, 100L, LocalDateTime.now().plusYears(1));
+        Enrollment enrollment = Enrollment.of(STUDENT_ID, COURSE_ID, LocalDateTime.now().plusYears(1));
         enrollment.cancel();
 
         // when & then
-        assertThatThrownBy(() -> enrollment.updateProgress(50))
+        assertThatThrownBy(() -> enrollment.updateProgress(VALID_PROGRESS_RATE))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", EnrollmentErrorCode.CANNOT_UPDATE_PROGRESS_FOR_NON_ENROLLED);
     }
@@ -97,10 +99,10 @@ class EnrollmentTest {
     @DisplayName("만료된 강의의 진도율 업데이트 시 BusinessException을 던진다.")
     void updateProgress_fail_if_expired() {
         // given
-        Enrollment enrollment = Enrollment.of(1L, 100L, LocalDateTime.now().minusDays(1));
+        Enrollment enrollment = Enrollment.of(STUDENT_ID, COURSE_ID, LocalDateTime.now().minusDays(1));
 
         // when & then
-        assertThatThrownBy(() -> enrollment.updateProgress(50))
+        assertThatThrownBy(() -> enrollment.updateProgress(VALID_PROGRESS_RATE))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", EnrollmentErrorCode.ENROLLMENT_EXPIRED_PROGRESS_UPDATE_DENIED);
     }
@@ -109,7 +111,7 @@ class EnrollmentTest {
     @DisplayName("수강 신청을 취소하면 상태가 CANCELED로 변경된다.")
     void cancel() {
         // given
-        Enrollment enrollment = Enrollment.of(1L, 100L, LocalDateTime.now().plusYears(1));
+        Enrollment enrollment = Enrollment.of(STUDENT_ID, COURSE_ID, LocalDateTime.now().plusYears(1));
 
         // when
         enrollment.cancel();
@@ -122,8 +124,8 @@ class EnrollmentTest {
     @DisplayName("이미 수료한 강의는 취소할 수 없다.")
     void cancel_fail_if_completed() {
         // given
-        Enrollment enrollment = Enrollment.of(1L, 100L, LocalDateTime.now().plusYears(1));
-        enrollment.updateProgress(100);
+        Enrollment enrollment = Enrollment.of(STUDENT_ID, COURSE_ID, LocalDateTime.now().plusYears(1));
+        enrollment.updateProgress(MAX_PROGRESS_RATE);
         // when & then
         assertThatThrownBy(enrollment::cancel)
                 .isInstanceOf(BusinessException.class)
@@ -134,7 +136,7 @@ class EnrollmentTest {
     @DisplayName("이미 취소된 강의는 다시 취소할 수 없다.")
     void cancel_fail_if_already_cancelled() {
         // given
-        Enrollment enrollment = Enrollment.of(1L, 100L, LocalDateTime.now().plusYears(1));
+        Enrollment enrollment = Enrollment.of(STUDENT_ID, COURSE_ID, LocalDateTime.now().plusYears(1));
         enrollment.cancel();
 
         // when & then
@@ -147,7 +149,7 @@ class EnrollmentTest {
     @DisplayName("만료된 강의는 취소할 수 없다.")
     void cancel_fail_if_expired() {
         // given
-        Enrollment enrollment = Enrollment.of(1L, 100L, LocalDateTime.now().minusDays(1));
+        Enrollment enrollment = Enrollment.of(STUDENT_ID, COURSE_ID, LocalDateTime.now().minusDays(1));
 
         // when & then
         assertThatThrownBy(enrollment::cancel)
@@ -161,7 +163,7 @@ class EnrollmentTest {
     void isExpired() {
         // given: 어제 날짜로 만료일 설정
         LocalDateTime pastDate = LocalDateTime.now().minusDays(1);
-        Enrollment enrollment = Enrollment.of(1L, 100L, pastDate);
+        Enrollment enrollment = Enrollment.of(STUDENT_ID, COURSE_ID, pastDate);
 
         // when
         boolean expired = enrollment.isExpired();
@@ -175,7 +177,7 @@ class EnrollmentTest {
     void isNotExpired() {
         // given: 내일 날짜로 만료일 설정
         LocalDateTime futureDate = LocalDateTime.now().plusDays(1);
-        Enrollment enrollment = Enrollment.of(1L, 100L, futureDate);
+        Enrollment enrollment = Enrollment.of(STUDENT_ID, COURSE_ID, futureDate);
 
         // when
         boolean expired = enrollment.isExpired();

--- a/src/test/java/com/lxp/aplus/enrollment/domain/EnrollmentTest.java
+++ b/src/test/java/com/lxp/aplus/enrollment/domain/EnrollmentTest.java
@@ -1,7 +1,12 @@
 package com.lxp.aplus.enrollment.domain;
 
+import com.lxp.aplus.common.error.BusinessException;
+import com.lxp.aplus.common.error.code.EnrollmentErrorCode;
+import com.lxp.aplus.common.error.code.GlobalErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.LocalDateTime;
 
@@ -18,7 +23,7 @@ class EnrollmentTest {
         LocalDateTime expiredAt = LocalDateTime.now().plusYears(1);
 
         // when
-        Enrollment enrollment = Enrollment.enroll(studentId, courseId, expiredAt);
+        Enrollment enrollment = Enrollment.of(studentId, courseId, expiredAt);
 
         // then
         assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.ENROLLED);
@@ -27,10 +32,32 @@ class EnrollmentTest {
     }
 
     @Test
+    @DisplayName("of 정적 팩토리 메서드는 인자가 null이면 BusinessException을 던진다.")
+    void of_fail_if_argument_is_null() {
+        // given
+        Long studentId = 1L;
+        Long courseId = 100L;
+        LocalDateTime expiredAt = LocalDateTime.now().plusYears(1);
+
+        // when & then
+        assertThatThrownBy(() -> Enrollment.of(null, courseId, expiredAt))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", GlobalErrorCode.INVALID_ARGUMENT);
+
+        assertThatThrownBy(() -> Enrollment.of(studentId, null, expiredAt))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", GlobalErrorCode.INVALID_ARGUMENT);
+
+        assertThatThrownBy(() -> Enrollment.of(studentId, courseId, null))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", GlobalErrorCode.INVALID_ARGUMENT);
+    }
+
+    @Test
     @DisplayName("진도율이 100%가 되면 자동으로 수료(COMPLETED) 상태로 변경된다.")
     void updateProgress_complete() {
         // given
-        Enrollment enrollment = Enrollment.enroll(1L, 100L, LocalDateTime.now().plusYears(1));
+        Enrollment enrollment = Enrollment.of(1L, 100L, LocalDateTime.now().plusYears(1));
 
         // when
         enrollment.updateProgress(100);
@@ -40,30 +67,120 @@ class EnrollmentTest {
         assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.COMPLETED);
     }
 
+    @DisplayName("유효하지 않은 진도율로 업데이트 시 BusinessException을 던진다.")
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 101})
+    void updateProgress_fail_if_invalid_rate(int invalidProgressRate) {
+        // given
+        Enrollment enrollment = Enrollment.of(1L, 100L, LocalDateTime.now().plusYears(1));
+
+        // when & then
+        assertThatThrownBy(() -> enrollment.updateProgress(invalidProgressRate))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", EnrollmentErrorCode.INVALID_PROGRESS_RATE);
+    }
+
+    @Test
+    @DisplayName("수강 중이 아닌 강의의 진도율 업데이트 시 BusinessException을 던진다.")
+    void updateProgress_fail_if_not_enrolled() {
+        // given
+        Enrollment enrollment = Enrollment.of(1L, 100L, LocalDateTime.now().plusYears(1));
+        enrollment.cancel();
+
+        // when & then
+        assertThatThrownBy(() -> enrollment.updateProgress(50))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", EnrollmentErrorCode.CANNOT_UPDATE_PROGRESS_FOR_NON_ENROLLED);
+    }
+
+    @Test
+    @DisplayName("만료된 강의의 진도율 업데이트 시 BusinessException을 던진다.")
+    void updateProgress_fail_if_expired() {
+        // given
+        Enrollment enrollment = Enrollment.of(1L, 100L, LocalDateTime.now().minusDays(1));
+
+        // when & then
+        assertThatThrownBy(() -> enrollment.updateProgress(50))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", EnrollmentErrorCode.ENROLLMENT_EXPIRED_PROGRESS_UPDATE_DENIED);
+    }
+
+    @Test
+    @DisplayName("수강 신청을 취소하면 상태가 CANCELED로 변경된다.")
+    void cancel() {
+        // given
+        Enrollment enrollment = Enrollment.of(1L, 100L, LocalDateTime.now().plusYears(1));
+
+        // when
+        enrollment.cancel();
+
+        // then
+        assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CANCELED);
+    }
+
     @Test
     @DisplayName("이미 수료한 강의는 취소할 수 없다.")
     void cancel_fail_if_completed() {
         // given
-        Enrollment enrollment = Enrollment.enroll(1L, 100L, LocalDateTime.now().plusYears(1));
-        enrollment.complete();
+        Enrollment enrollment = Enrollment.of(1L, 100L, LocalDateTime.now().plusYears(1));
+        enrollment.updateProgress(100);
+        // when & then
+        assertThatThrownBy(enrollment::cancel)
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", EnrollmentErrorCode.CANNOT_CANCEL_COMPLETED_ENROLLMENT);
+    }
+
+    @Test
+    @DisplayName("이미 취소된 강의는 다시 취소할 수 없다.")
+    void cancel_fail_if_already_cancelled() {
+        // given
+        Enrollment enrollment = Enrollment.of(1L, 100L, LocalDateTime.now().plusYears(1));
+        enrollment.cancel();
 
         // when & then
         assertThatThrownBy(enrollment::cancel)
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("이미 수료한 강의는 취소할 수 없습니다.");
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", EnrollmentErrorCode.ALREADY_CANCELLED_ENROLLMENT);
     }
+
+    @Test
+    @DisplayName("만료된 강의는 취소할 수 없다.")
+    void cancel_fail_if_expired() {
+        // given
+        Enrollment enrollment = Enrollment.of(1L, 100L, LocalDateTime.now().minusDays(1));
+
+        // when & then
+        assertThatThrownBy(enrollment::cancel)
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", EnrollmentErrorCode.CANNOT_CANCEL_EXPIRED_ENROLLMENT);
+    }
+
 
     @Test
     @DisplayName("수강 기간이 지났는지 확인한다.")
     void isExpired() {
         // given: 어제 날짜로 만료일 설정
         LocalDateTime pastDate = LocalDateTime.now().minusDays(1);
-        Enrollment enrollment = Enrollment.enroll(1L, 100L, pastDate);
+        Enrollment enrollment = Enrollment.of(1L, 100L, pastDate);
 
         // when
         boolean expired = enrollment.isExpired();
 
         // then
         assertThat(expired).isTrue();
+    }
+
+    @Test
+    @DisplayName("수강 기간이 지나지 않았는지 확인한다.")
+    void isNotExpired() {
+        // given: 내일 날짜로 만료일 설정
+        LocalDateTime futureDate = LocalDateTime.now().plusDays(1);
+        Enrollment enrollment = Enrollment.of(1L, 100L, futureDate);
+
+        // when
+        boolean expired = enrollment.isExpired();
+
+        // then
+        assertThat(expired).isFalse();
     }
 }


### PR DESCRIPTION
## ✨ 요약
 수강에 핵심이 되는 Entity와 Repository Interface를 구현했습니다. 
## 📝 작업 내용
 -Enrollment Entity  생성 (UniqueConstraint 적용)
- Enrollment Enum 정의
- EnrollmentRepository 인터페이스
- 비지니스 로직 (수강신청, 취소, 수료) 캡슐화

## 💭 주의 사항

## 💡 리뷰 포인트
Entity 내부의 비지니스 로직이 적절한지, UniqueConstraint가 잘 했는지 봐주세요.
## ✅ 테스트
- [x] 로컬 빌드/실행
- [x] 단위 테스트 추가/통과
- [ ] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
<img width="850" height="293" alt="image" src="https://github.com/user-attachments/assets/225dc858-9a5e-452a-b3f1-2530d9ae5f52" />


