### PR TITLE
[FEAT] User Entity 추가

### DIFF
--- a/src/main/java/com/lxp/aplus/user/domain/entity/README.md
+++ b/src/main/java/com/lxp/aplus/user/domain/entity/README.md
@@ -1,0 +1,91 @@
+# User Domain Entity 구조
+
+## 개요
+User 도메인의 엔티티 구조 및 설계 의도
+
+## 엔티티 구조
+
+### User (Root Aggregate)
+- **역할**: User 도메인의 Root Aggregate
+- **관계**: Role과 1:N 단방향 관계
+
+#### 주요 필드
+- **기본 정보**: `name`, `nickName`, `email`, `phoneNumber`, `password`
+- **역할 관리**: `roles` (OneToMany, 단방향)
+- **상태 관리**: `status` (UserStatus enum, 기본값: PENDING)
+- **시간 추적**: `createdAt`, `updatedAt`, `deletedAt` (JPA Auditing)
+
+#### 불변 필드
+- `id`: 자동 생성, 변경 불가
+- `createdAt`: 생성 시 자동 설정, 변경 불가
+
+#### 도메인 메서드
+- `createUser()`: 정적 팩토리 메서드 (기본 STUDENT 역할 자동 설정)
+- `addRole()`: 역할 추가
+- `updateUserInfo()`: 닉네임, 이메일 업데이트
+- `updateStatus()`: 사용자 상태 업데이트
+- `changePassword()`: 비밀번호 변경
+- `delete()`: Soft Delete 처리
+
+### Role
+- **역할**: 사용자별 역할 관리
+- **관계**: User와 1:N 관계 (단방향, User → Role)
+
+#### 주요 필드
+- `id`: 자동 생성
+- `roleType`: 역할 타입 (불변, updatable = false)
+- `createdAt`: 생성 시 자동 설정 (불변)
+- `deletedAt`: Soft Delete용
+
+#### 제약조건
+- `(user_id, role_type)` 복합 유니크 제약조건
+  - 한 사용자가 동일한 역할을 중복으로 가질 수 없음
+
+#### 불변 필드
+- `roleType`: 생성 후 변경 불가
+- `createdAt`: 생성 시 자동 설정, 변경 불가
+
+## 연관관계 설계
+
+### User ↔ Role
+- **방향**: 단방향 (User → Role)
+- **타입**: OneToMany
+- **매핑**: `@JoinColumn(name = "user_id")`
+- **Cascade**: ALL (User 저장 시 Role도 함께 저장)
+- **Fetch**: LAZY
+
+**설계 이유**:
+- Role에서 User를 조회할 필요가 없음
+- 단방향으로 설계하여 불필요한 양방향 참조 제거
+- User의 역할 목록만 조회하면 충분
+
+## 불변성 설계
+
+### User
+- `id`, `createdAt`: 생성 후 변경 불가
+
+### Role
+- `roleType`: 생성 후 변경 불가 (업데이트 불가)
+- 역할 변경이 필요한 경우: 기존 Role 삭제 후 새 Role 생성
+
+## Soft Delete
+- `deletedAt` 필드를 통한 Soft Delete 지원
+- `delete()` 메서드로 `deletedAt`에 현재 시간 설정
+- 실제 데이터는 DB에 유지, 조회 시 `deletedAt IS NULL` 조건 필요
+
+## JPA Auditing
+- `@EntityListeners(AuditingEntityListener.class)` 적용
+- `createdAt`, `updatedAt` 자동 관리
+- `@CreatedDate`, `@LastModifiedDate` 사용
+
+## 패키지 구조
+```
+com.lxp.aplus.user.domain
+├── entity/
+│   ├── User.java
+│   └── Role.java
+└── enums/
+    ├── RoleType.java
+    └── UserStatus.java
+```
+

--- a/src/main/java/com/lxp/aplus/user/domain/entity/Role.java
+++ b/src/main/java/com/lxp/aplus/user/domain/entity/Role.java
@@ -24,7 +24,7 @@ public class Role {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "user_id", nullable = true, updatable = false, insertable = false)
+    @Column(name = "user_id", updatable = false, insertable = false)
     private Long userId;
 
     @Enumerated(EnumType.STRING)
@@ -37,5 +37,20 @@ public class Role {
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    protected static Role of(Long userId, RoleType roleType) {
+        return Role.builder()
+                .userId(userId)
+                .roleType(roleType)
+                .build();
+    }
+
+    // TODO : 권한 회수 정책 검토 필요
+    //  권한 부여 이력 확인을 위해 soft delete정책을 적용하였으나
+    //  예를들어 강사 권한을 회수한 이후 다시 재부여를 했을 경우 unique 제약조건에 걸리게 됨.
+    //  해당케이스를 고려해서 unique 제약조건을 해제하거나, 권한 회수 정책을 변경할 필요가 있음.
+    protected void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
 }
 

--- a/src/main/java/com/lxp/aplus/user/domain/entity/Role.java
+++ b/src/main/java/com/lxp/aplus/user/domain/entity/Role.java
@@ -1,0 +1,41 @@
+package com.lxp.aplus.user.domain.entity;
+
+import com.lxp.aplus.user.domain.enums.RoleType;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "roles",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"user_id", "role_type"})
+        })
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class Role {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = true, updatable = false, insertable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role_type", nullable = false, updatable = false)
+    private RoleType roleType;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+}
+

--- a/src/main/java/com/lxp/aplus/user/domain/entity/User.java
+++ b/src/main/java/com/lxp/aplus/user/domain/entity/User.java
@@ -1,0 +1,102 @@
+package com.lxp.aplus.user.domain.entity;
+
+import com.lxp.aplus.user.domain.enums.RoleType;
+import com.lxp.aplus.user.domain.enums.UserStatus;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Builder
+@Entity
+@Table(name = "users")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String name;
+
+    @Column(name = "nick_name")
+    private String nickName;
+
+    @Column
+    private String email;
+
+    @Column(name = "phone_number")
+    private String phoneNumber;
+
+    // TODO : 암호화 필요
+    @Column
+    private String password;
+
+    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    @Builder.Default
+    private List<Role> roles = new ArrayList<>();
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    @Builder.Default
+    private UserStatus status = UserStatus.PENDING;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public void addRole(RoleType roleType) {
+        Role role = Role.builder()
+                .userId(this.id)
+                .roleType(roleType)
+                .build();
+        this.roles.add(role);
+    }
+
+    public void updateUserInfo(String nickName, String email) {
+        this.nickName = nickName;
+        this.email = email;
+    }
+
+    // TODO : 상태값에 따른 비즈니스 로직은 서비스 레이어에서 처리
+    public void updateStatus(UserStatus status) {
+        this.status = status;
+    }
+
+    public void changePassword(String password) {
+        // TODO : 암호화 필요
+        this.password = password;
+    }
+
+    public static User createUser(String name, String email, String password) {
+        User user = User.builder()
+                .name(name)
+                .email(email)
+                .password(password)
+                .build();
+
+        user.addRole(RoleType.STUDENT);
+        return user;
+    }
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/com/lxp/aplus/user/domain/entity/User.java
+++ b/src/main/java/com/lxp/aplus/user/domain/entity/User.java
@@ -1,11 +1,10 @@
 package com.lxp.aplus.user.domain.entity;
 
+import com.lxp.aplus.common.domain.BaseAggregateRoot;
 import com.lxp.aplus.user.domain.enums.RoleType;
 import com.lxp.aplus.user.domain.enums.UserStatus;
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
@@ -19,7 +18,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class User {
+public class User extends BaseAggregateRoot {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -50,22 +49,22 @@ public class User {
     @Builder.Default
     private UserStatus status = UserStatus.PENDING;
 
-    @CreatedDate
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    public void addRole(RoleType roleType) {
-        Role role = Role.builder()
-                .userId(this.id)
-                .roleType(roleType)
+    public static User of(String name, String email, String password) {
+        User user = User.builder()
+                .name(name)
+                .email(email)
+                .password(password)
                 .build();
+
+        user.addRole(RoleType.STUDENT);
+        return user;
+    }
+
+    public void addRole(RoleType roleType) {
+        Role role = Role.of(this.id, roleType);
         this.roles.add(role);
     }
 
@@ -79,20 +78,9 @@ public class User {
         this.status = status;
     }
 
+    // TODO : 암호화 필요
     public void changePassword(String password) {
-        // TODO : 암호화 필요
         this.password = password;
-    }
-
-    public static User createUser(String name, String email, String password) {
-        User user = User.builder()
-                .name(name)
-                .email(email)
-                .password(password)
-                .build();
-
-        user.addRole(RoleType.STUDENT);
-        return user;
     }
 
     public void delete() {

--- a/src/main/java/com/lxp/aplus/user/domain/enums/RoleType.java
+++ b/src/main/java/com/lxp/aplus/user/domain/enums/RoleType.java
@@ -1,0 +1,8 @@
+package com.lxp.aplus.user.domain.enums;
+
+public enum RoleType {
+    STUDENT,
+    INSTRUCTOR,
+    ADMIN
+}
+

--- a/src/main/java/com/lxp/aplus/user/domain/enums/UserStatus.java
+++ b/src/main/java/com/lxp/aplus/user/domain/enums/UserStatus.java
@@ -1,0 +1,20 @@
+package com.lxp.aplus.user.domain.enums;
+
+/**
+ * ACTIVE	정상 회원
+ * INACTIVE	휴면 회원
+ * WITHDRAWN	탈퇴 회원
+ * PENDING	가입대기(이메일 인증 전)	DEFAULT VALUE
+ * SUSPENDED	일시정지	Unused
+ * BANNED	영구정지	Unused
+ * BLOCKED	관리자에의한 서비스 접근제한	Unused
+ */
+public enum UserStatus {
+    ACTIVE,
+    INACTIVE,
+    WITHDRAWN,
+    PENDING,
+    SUSPENDED,
+    BANNED,
+    BLOCKED;
+}


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ✨ 요약
User 도메인의 엔티티 구조 및 설계 의도

## 📝 작업 내용
- User 도메인의 Root Aggregate
- Role과 1:N 단방향 관계

## 💭 주의 사항
- Role에서 User를 조회할 필요가 없음

## 💡 리뷰 포인트
- 단방향으로 설계하여 불필요한 양방향 참조 제거
- User의 역할 목록만 조회하면 충분

## ✅ 테스트
- [x] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [ ] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
