### PR TITLE
[FEAT] Lecture LectureResource Entity 구현

### DIFF
--- a/src/main/java/com/lxp/aplus/course/domain/Lecture.java
+++ b/src/main/java/com/lxp/aplus/course/domain/Lecture.java
@@ -2,11 +2,15 @@ package com.lxp.aplus.course.domain;
 
 import com.lxp.aplus.common.domain.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "lectures")
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 class Lecture extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -15,6 +19,9 @@ class Lecture extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "section_id", nullable = false)
     private Section section;
+
+    @OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<LectureResource> lectureResources = new ArrayList<>();
 
     @Column (nullable = false)
     private String title;

--- a/src/main/java/com/lxp/aplus/course/domain/Lecture.java
+++ b/src/main/java/com/lxp/aplus/course/domain/Lecture.java
@@ -11,7 +11,7 @@ import java.util.List;
 @Entity
 @Table(name = "lectures")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-class Lecture extends BaseTimeEntity {
+public class Lecture extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/lxp/aplus/course/domain/Lecture.java
+++ b/src/main/java/com/lxp/aplus/course/domain/Lecture.java
@@ -3,6 +3,7 @@ package com.lxp.aplus.course.domain;
 import com.lxp.aplus.common.domain.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
@@ -11,6 +12,7 @@ import java.util.List;
 @Entity
 @Table(name = "lectures")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Lecture extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/lxp/aplus/course/domain/Lecture.java
+++ b/src/main/java/com/lxp/aplus/course/domain/Lecture.java
@@ -1,0 +1,27 @@
+package com.lxp.aplus.course.domain;
+
+import com.lxp.aplus.common.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "lectures")
+@NoArgsConstructor
+class Lecture extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "section_id", nullable = false)
+    private Section section;
+
+    @Column (nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String description;
+
+    @Column(name = "order_index", nullable = false)
+    private int orderIndex;
+}

--- a/src/main/java/com/lxp/aplus/course/domain/LectureResource.java
+++ b/src/main/java/com/lxp/aplus/course/domain/LectureResource.java
@@ -2,11 +2,14 @@ package com.lxp.aplus.course.domain;
 
 import com.lxp.aplus.common.domain.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Entity
 @Table(name = "lecture_resources")
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class LectureResource extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,9 +28,13 @@ public class LectureResource extends BaseTimeEntity {
     @Column(name = "original_file_name", nullable = false)
     private String originalFileName;
 
+    @Column(name = "duration_seconds")
+    private Integer durationSeconds;
+
     @Column(name = "file_key")
     private String fileKey;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "resource_type", nullable = false)
     private ResourceType resourceType;
 

--- a/src/main/java/com/lxp/aplus/course/domain/LectureResource.java
+++ b/src/main/java/com/lxp/aplus/course/domain/LectureResource.java
@@ -1,0 +1,39 @@
+package com.lxp.aplus.course.domain;
+
+import com.lxp.aplus.common.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "lecture_resources")
+@NoArgsConstructor
+public class LectureResource extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lecture_id", nullable = false)
+    private Lecture lecture;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String description;
+
+    @Column(name = "original_file_name", nullable = false)
+    private String originalFileName;
+
+    @Column(name = "file_key")
+    private String fileKey;
+
+    @Column(name = "resource_type", nullable = false)
+    private ResourceType resourceType;
+
+    @Column(name = "is_preview")
+    private boolean isPreview;
+
+    @Column(name = "is_downloadable")
+    private boolean isDownloadable;
+}

--- a/src/main/java/com/lxp/aplus/course/domain/LectureResource.java
+++ b/src/main/java/com/lxp/aplus/course/domain/LectureResource.java
@@ -3,6 +3,7 @@ package com.lxp.aplus.course.domain;
 import com.lxp.aplus.common.domain.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
@@ -10,6 +11,7 @@ import java.util.List;
 @Entity
 @Table(name = "lecture_resources")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class LectureResource extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/lxp/aplus/course/domain/LectureResource.java
+++ b/src/main/java/com/lxp/aplus/course/domain/LectureResource.java
@@ -24,16 +24,13 @@ public class LectureResource extends BaseTimeEntity {
     @Column(nullable = false)
     private String title;
 
-    @Column(nullable = false)
-    private String description;
-
     @Column(name = "original_file_name", nullable = false)
     private String originalFileName;
 
     @Column(name = "duration_seconds")
     private Integer durationSeconds;
 
-    @Column(name = "file_key")
+    @Column(name = "file_key", nullable = false)
     private String fileKey;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/lxp/aplus/course/domain/ResourceType.java
+++ b/src/main/java/com/lxp/aplus/course/domain/ResourceType.java
@@ -4,13 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum ResourceType {
-    VIDEO("video"),
-    PDF("pdf"),
-    QUIZ("quiz");
-
-    private final String type;
-
-    ResourceType(String type) {
-        this.type = type;
-    }
+    VIDEO,
+    PDF,
+    QUIZ
 }

--- a/src/main/java/com/lxp/aplus/course/domain/ResourceType.java
+++ b/src/main/java/com/lxp/aplus/course/domain/ResourceType.java
@@ -1,0 +1,16 @@
+package com.lxp.aplus.course.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum ResourceType {
+    VIDEO("video"),
+    PDF("pdf"),
+    QUIZ("quiz");
+
+    private final String type;
+
+    ResourceType(String type) {
+        this.type = type;
+    }
+}

--- a/src/main/java/com/lxp/aplus/course/domain/ResourceType.java
+++ b/src/main/java/com/lxp/aplus/course/domain/ResourceType.java
@@ -1,10 +1,13 @@
 package com.lxp.aplus.course.domain;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
-@Getter
+@RequiredArgsConstructor
 public enum ResourceType {
-    VIDEO,
-    PDF,
-    QUIZ
+    VIDEO("영상"),
+    PDF("PDF 자료");
+
+    @Getter
+    private final String displayName;
 }


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ✨ 요약
강의(Lecture), 강의자료(LectureResource) 도메인 엔티티와 ResourceType enum의 기본 필드 구성을 추가했습니다.
현재는 행위 로직 없이 엔티티 스켈레톤 및 관계 설정 중심으로만 구성되어 있습니다.

## 📝 작업 내용
### Lecture 엔티티
- Section 연관관계 설정 (`@ManyToOne`)
- 강의 기본 메타 필드 정의  
  - `title`
  - `description`
  - `orderIndex`
- `LectureResource` 리스트 연관관계 매핑

### LectureResource 엔티티
- Lecture 연관관계 설정 (`@ManyToOne`)
- 강의자료 메타 필드 정의  
  - `title`
  - `description`
  - `originalFileName`
  - `fileKey`
- 콘텐츠 타입별 속성 필드 추가  
  - `durationSeconds`
  - `isPreview`
  - `isDownloadable`
- ResourceType 매핑 적용  
  - `@Enumerated(EnumType.STRING)`

### ResourceType enum
- 타입 정의: `VIDEO`, `PDF`, `QUIZ`

### 공통
- 모든 엔티티 기본 생성자 `PROTECTED` 접근 제한 설정  
  (`@NoArgsConstructor(access = AccessLevel.PROTECTED)`)

## 💭 주의 사항

- 본 PR은 **도메인 필드 정의 및 관계 매핑 단계까지만 포함**되어 있습니다.
  - 불변식 검증 로직
  - 생성 팩토리/도메인 메서드
  - 서비스 / API 연결 로직

  은 이후 PR에서 단계적으로 추가 예정입니다.

- 파일 관련 메타 데이터(`fileSize`, `contentType`)는  
  현재 요구사항 범위를 넘지 않아 이번 PR에는 포함하지 않았습니다.

## 💡 리뷰 포인트
- Lecture ↔ LectureResource 연관관계 매핑 구조 검토
- 후속 도메인 로직 추가 시 엔티티 책임 분리 방향

## ✅ 테스트
- [x] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [ ] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
