### PR TITLE
[FEAT] 수강 신청 API 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,12 +28,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,10 +28,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/lxp/aplus/common/result/code/EnrollmentResultCode.java
+++ b/src/main/java/com/lxp/aplus/common/result/code/EnrollmentResultCode.java
@@ -14,7 +14,7 @@ public enum EnrollmentResultCode implements ResultCode {
 
     UPDATE_PROGRESS_SUCCESS(HttpStatus.OK, "SP001", "진도율이 갱신되었습니다."),
     GET_PROGRESS_SUCCESS(HttpStatus.OK, "SP002", "학습 이력을 조회하였습니다."),
-    CANCEL_ENROLLMENT_SUCCESS(HttpStatus.OK, "SE003", "수강이 정상적으로 취소되었습니다.");
+    CANCEL_ENROLLMENT_SUCCESS(HttpStatus.OK, "SE004", "수강이 정상적으로 취소되었습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/lxp/aplus/enrollment/application/command/EnrollmentCommand.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/command/EnrollmentCommand.java
@@ -3,9 +3,9 @@ package com.lxp.aplus.enrollment.application.command;
 import jakarta.validation.constraints.NotNull;
 
 public record EnrollmentCommand(
-        @NotNull String impUid,
-        @NotNull String merchantUid,
-        @NotNull Long studentId,
-        @NotNull Long courseId
+        @NotNull(message = "impUid는 필수입니다.") String impUid,
+        @NotNull(message = "merchantUid는 필수입니다.") String merchantUid,
+        @NotNull(message = "studentId는 필수입니다.") Long studentId,
+        @NotNull(message = "courseId는 필수입니다.") Long courseId
 ) {
 }

--- a/src/main/java/com/lxp/aplus/enrollment/application/command/EnrollmentCommand.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/command/EnrollmentCommand.java
@@ -1,0 +1,11 @@
+package com.lxp.aplus.enrollment.application.command;
+
+import jakarta.validation.constraints.NotNull;
+
+public record EnrollmentCommand(
+        @NotNull String impUid,
+        @NotNull String merchantUid,
+        @NotNull Long studentId,
+        @NotNull Long courseId
+) {
+}

--- a/src/main/java/com/lxp/aplus/enrollment/application/port/out/CourseFinder.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/port/out/CourseFinder.java
@@ -1,0 +1,7 @@
+package com.lxp.aplus.enrollment.application.port.out;
+
+import java.util.Optional;
+
+public interface CourseFinder {
+    Optional<CourseInfo> findCourseById(Long courseId);
+}

--- a/src/main/java/com/lxp/aplus/enrollment/application/port/out/CourseInfo.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/port/out/CourseInfo.java
@@ -1,0 +1,6 @@
+package com.lxp.aplus.enrollment.application.port.out;
+
+public record CourseInfo(
+        Long courseId
+) {
+}

--- a/src/main/java/com/lxp/aplus/enrollment/application/result/EnrollmentCreationResult.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/result/EnrollmentCreationResult.java
@@ -1,0 +1,12 @@
+package com.lxp.aplus.enrollment.application.result;
+
+import java.util.List;
+
+public record EnrollmentCreationResult(
+        int totalCount,
+        List<EnrollmentDetailResult> enrollments
+) {
+    public static EnrollmentCreationResult of(List<EnrollmentDetailResult> enrollments) {
+        return new EnrollmentCreationResult(enrollments.size(), enrollments);
+    }
+}

--- a/src/main/java/com/lxp/aplus/enrollment/application/result/EnrollmentCreationResult.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/result/EnrollmentCreationResult.java
@@ -6,7 +6,7 @@ public record EnrollmentCreationResult(
         int totalCount,
         List<EnrollmentDetailResult> enrollments
 ) {
-    public static EnrollmentCreationResult of(List<EnrollmentDetailResult> enrollments) {
+    public static EnrollmentCreationResult from(List<EnrollmentDetailResult> enrollments) {
         return new EnrollmentCreationResult(enrollments.size(), enrollments);
     }
 }

--- a/src/main/java/com/lxp/aplus/enrollment/application/result/EnrollmentDetailResult.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/result/EnrollmentDetailResult.java
@@ -1,0 +1,26 @@
+package com.lxp.aplus.enrollment.application.result;
+
+import com.lxp.aplus.enrollment.domain.Enrollment;
+import com.lxp.aplus.enrollment.domain.EnrollmentStatus;
+
+import java.time.LocalDateTime;
+
+public record EnrollmentDetailResult(
+        Long enrollmentId,
+        Long studentId,
+        Long courseId,
+        EnrollmentStatus status,
+        LocalDateTime createdAt,
+        LocalDateTime expiredAt
+) {
+    public static EnrollmentDetailResult from(Enrollment enrollment) {
+        return new EnrollmentDetailResult(
+                enrollment.getId(),
+                enrollment.getStudentId(),
+                enrollment.getCourseId(),
+                enrollment.getStatus(),
+                enrollment.getCreatedAt(),
+                enrollment.getExpiredAt()
+        );
+    }
+}

--- a/src/main/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentCommandUseCase.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentCommandUseCase.java
@@ -24,13 +24,11 @@ public class EnrollmentCommandUseCase{
     private final CourseFinder courseFinder;
 
     /**
-     * 수강 신청 비즈니스 로직을 수행합니다. (Transaction Script & Domain Model Pattern)
+     * 수강 신청 비즈니스 로직을 수행합니다.
      * * <p> 처리 흐름:
-     * 1. [강의 조회] 신청하려는 강의가 존재하는지 확인
-     * 2. [결제 검증] 요청된 결제 정보(impUid)가 유효하고, 강의료와 일치하는지 검증 (PaymentValidator 위임)
-     * 3. [중복 검사] 이미 수강 중인 강의인지 확인 (중복 시 예외 발생)
-     * 4. [엔티티 생성] 수강 기간(2년) 정책을 적용하여 Enrollment 엔티티 생성
-     * 5. [저장] 생성된 수강 내역 저장 및 결과 반환
+     * 1. [중복 검사] 이미 수강 중인 강의인지 확인 (중복 시 예외 발생)
+     * 2. [엔티티 생성] 수강 기간(2년) 정책을 적용하여 Enrollment 엔티티 생성
+     * 3. [저장] 생성된 수강 내역 저장 및 결과 반환
      * </p>
      *
      * @param command 수강 신청 요청 데이터 (studentId, courseId, impUid 등)

--- a/src/main/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentCommandUseCase.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentCommandUseCase.java
@@ -2,15 +2,15 @@ package com.lxp.aplus.enrollment.application.usecase;
 
 import com.lxp.aplus.common.error.BusinessException;
 import com.lxp.aplus.common.error.code.EnrollmentErrorCode;
-import com.lxp.aplus.course.domain.Course;
-import com.lxp.aplus.course.domain.CourseRepository;
 import com.lxp.aplus.enrollment.application.command.EnrollmentCommand;
+import com.lxp.aplus.enrollment.application.port.out.CourseFinder;
 import com.lxp.aplus.enrollment.application.result.EnrollmentCreationResult;
 import com.lxp.aplus.enrollment.application.result.EnrollmentDetailResult;
 import com.lxp.aplus.enrollment.domain.Enrollment;
 import com.lxp.aplus.enrollment.domain.EnrollmentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -21,26 +21,40 @@ import java.util.List;
 public class EnrollmentCommandUseCase{
 
     private final EnrollmentRepository enrollmentRepository;
-    private final CourseRepository courseRepository;
+    private final CourseFinder courseFinder;
 
-    @Transactional
+    /**
+     * 수강 신청 비즈니스 로직을 수행합니다. (Transaction Script & Domain Model Pattern)
+     * * <p> 처리 흐름:
+     * 1. [강의 조회] 신청하려는 강의가 존재하는지 확인
+     * 2. [결제 검증] 요청된 결제 정보(impUid)가 유효하고, 강의료와 일치하는지 검증 (PaymentValidator 위임)
+     * 3. [중복 검사] 이미 수강 중인 강의인지 확인 (중복 시 예외 발생)
+     * 4. [엔티티 생성] 수강 기간(2년) 정책을 적용하여 Enrollment 엔티티 생성
+     * 5. [저장] 생성된 수강 내역 저장 및 결과 반환
+     * </p>
+     *
+     * @param command 수강 신청 요청 데이터 (studentId, courseId, impUid 등)
+     * @return EnrollmentCreationResult 생성된 수강 내역 정보
+     */
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public EnrollmentCreationResult enroll(EnrollmentCommand command) {
         Long courseId = command.courseId();
 
-        Course course = courseRepository.findById(courseId)
+        courseFinder.findCourseById(courseId)
                 .orElseThrow(() -> new BusinessException(EnrollmentErrorCode.ENROLLMENT_COURSE_NOT_FOUND));
+
         if (enrollmentRepository.existsByStudentIdAndCourseId(command.studentId(), courseId)) {
             throw new BusinessException(EnrollmentErrorCode.ALREADY_ENROLLED_COURSE);
         }
 
         LocalDateTime expiredAt = LocalDateTime.now().plusYears(2);
-        
+
         Enrollment enrollmentToSave = Enrollment.of(command.studentId(), courseId, expiredAt);
 
         Enrollment savedEnrollment = enrollmentRepository.save(enrollmentToSave);
 
         EnrollmentDetailResult createdEnrollment = EnrollmentDetailResult.from(savedEnrollment);
 
-        return EnrollmentCreationResult.of(List.of(createdEnrollment));
+        return EnrollmentCreationResult.from(List.of(createdEnrollment));
     }
 }

--- a/src/main/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentCommandUseCase.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentCommandUseCase.java
@@ -1,0 +1,46 @@
+package com.lxp.aplus.enrollment.application.usecase;
+
+import com.lxp.aplus.common.error.BusinessException;
+import com.lxp.aplus.common.error.code.EnrollmentErrorCode;
+import com.lxp.aplus.course.domain.Course;
+import com.lxp.aplus.course.domain.CourseRepository;
+import com.lxp.aplus.enrollment.application.command.EnrollmentCommand;
+import com.lxp.aplus.enrollment.application.result.EnrollmentCreationResult;
+import com.lxp.aplus.enrollment.application.result.EnrollmentDetailResult;
+import com.lxp.aplus.enrollment.domain.Enrollment;
+import com.lxp.aplus.enrollment.domain.EnrollmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class EnrollmentCommandUseCase{
+
+    private final EnrollmentRepository enrollmentRepository;
+    private final CourseRepository courseRepository;
+
+    @Transactional
+    public EnrollmentCreationResult enroll(EnrollmentCommand command) {
+        Long courseId = command.courseId();
+
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new BusinessException(EnrollmentErrorCode.ENROLLMENT_COURSE_NOT_FOUND));
+        if (enrollmentRepository.existsByStudentIdAndCourseId(command.studentId(), courseId)) {
+            throw new BusinessException(EnrollmentErrorCode.ALREADY_ENROLLED_COURSE);
+        }
+
+        LocalDateTime expiredAt = LocalDateTime.now().plusYears(2);
+        
+        Enrollment enrollmentToSave = Enrollment.of(command.studentId(), courseId, expiredAt);
+
+        Enrollment savedEnrollment = enrollmentRepository.save(enrollmentToSave);
+
+        EnrollmentDetailResult createdEnrollment = EnrollmentDetailResult.from(savedEnrollment);
+
+        return EnrollmentCreationResult.of(List.of(createdEnrollment));
+    }
+}

--- a/src/main/java/com/lxp/aplus/enrollment/domain/EnrollmentRepository.java
+++ b/src/main/java/com/lxp/aplus/enrollment/domain/EnrollmentRepository.java
@@ -1,10 +1,13 @@
 package com.lxp.aplus.enrollment.domain;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface EnrollmentRepository {
 
     Enrollment save(Enrollment enrollment);
+    
+    List<Enrollment> saveAll(List<Enrollment> enrollments);
 
     Optional<Enrollment> findById(Long id);
 

--- a/src/main/java/com/lxp/aplus/enrollment/infrastructure/adapter/CourseFinderAdapter.java
+++ b/src/main/java/com/lxp/aplus/enrollment/infrastructure/adapter/CourseFinderAdapter.java
@@ -1,0 +1,26 @@
+package com.lxp.aplus.enrollment.infrastructure.adapter;
+
+import com.lxp.aplus.enrollment.application.port.out.CourseFinder;
+import com.lxp.aplus.enrollment.application.port.out.CourseInfo;
+
+
+import com.lxp.aplus.course.domain.CourseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class CourseFinderAdapter implements CourseFinder {
+
+    private final CourseRepository courseRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<CourseInfo> findCourseById(Long courseId) {
+        return courseRepository.findById(courseId)
+                .map(course -> new CourseInfo(course.getId()));
+    }
+}

--- a/src/main/java/com/lxp/aplus/enrollment/infrastructure/persistence/EnrollmentJpaRepository.java
+++ b/src/main/java/com/lxp/aplus/enrollment/infrastructure/persistence/EnrollmentJpaRepository.java
@@ -1,0 +1,11 @@
+package com.lxp.aplus.enrollment.infrastructure.persistence;
+
+import com.lxp.aplus.enrollment.domain.Enrollment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface EnrollmentJpaRepository extends JpaRepository<Enrollment, Long> {
+    boolean existsByStudentIdAndCourseId(Long studentId, Long courseId);
+    Optional<Enrollment> findByStudentIdAndCourseId(Long studentId, Long courseId);
+}

--- a/src/main/java/com/lxp/aplus/enrollment/infrastructure/persistence/EnrollmentRepositoryImpl.java
+++ b/src/main/java/com/lxp/aplus/enrollment/infrastructure/persistence/EnrollmentRepositoryImpl.java
@@ -1,0 +1,42 @@
+package com.lxp.aplus.enrollment.infrastructure.persistence;
+
+import com.lxp.aplus.enrollment.domain.Enrollment;
+import com.lxp.aplus.enrollment.domain.EnrollmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class EnrollmentRepositoryImpl implements EnrollmentRepository {
+
+    private final EnrollmentJpaRepository jpaRepository;
+
+    @Override
+    public Enrollment save(Enrollment enrollment) {
+        return jpaRepository.save(enrollment);
+    }
+
+    @Override
+    public List<Enrollment> saveAll(List<Enrollment> enrollments) {
+        return jpaRepository.saveAll(enrollments);
+    }
+
+    @Override
+    public Optional<Enrollment> findById(Long id) {
+        return jpaRepository.findById(id);
+    }
+
+    @Override
+    public boolean existsByStudentIdAndCourseId(Long studentId, Long courseId) {
+        return jpaRepository.existsByStudentIdAndCourseId(studentId, courseId);
+    }
+
+    @Override
+    public Optional<Enrollment> findByStudentIdAndCourseId(Long studentId, Long courseId) {
+        return jpaRepository.findByStudentIdAndCourseId(studentId, courseId);
+    }
+
+}

--- a/src/main/java/com/lxp/aplus/enrollment/presentation/controller/EnrollmentController.java
+++ b/src/main/java/com/lxp/aplus/enrollment/presentation/controller/EnrollmentController.java
@@ -1,16 +1,7 @@
 package com.lxp.aplus.enrollment.presentation.controller;
 
-import com.lxp.aplus.common.result.ResultResponse;
-import com.lxp.aplus.common.result.code.EnrollmentResultCode;
-import com.lxp.aplus.enrollment.application.result.EnrollmentCreationResult;
 import com.lxp.aplus.enrollment.application.usecase.EnrollmentCommandUseCase;
-import com.lxp.aplus.enrollment.presentation.request.EnrollmentRequest;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,14 +12,4 @@ public class EnrollmentController {
 
     private final EnrollmentCommandUseCase enrollmentCommandUseCase;
 
-    @PostMapping
-    public ResponseEntity<ResultResponse<EnrollmentCreationResult>> enroll(
-            @AuthenticationPrincipal Long studentId,
-            @Valid @RequestBody EnrollmentRequest request) {
-        EnrollmentCreationResult enrollmentCreationResult = enrollmentCommandUseCase.enroll(request.toCommand(studentId));
-
-        return ResponseEntity.ok(
-                ResultResponse.of(EnrollmentResultCode.ENROLLMENT_SUCCESS, enrollmentCreationResult)
-        );
-    }
 }

--- a/src/main/java/com/lxp/aplus/enrollment/presentation/controller/EnrollmentController.java
+++ b/src/main/java/com/lxp/aplus/enrollment/presentation/controller/EnrollmentController.java
@@ -1,0 +1,35 @@
+package com.lxp.aplus.enrollment.presentation.controller;
+
+import com.lxp.aplus.common.result.ResultResponse;
+import com.lxp.aplus.common.result.code.EnrollmentResultCode;
+import com.lxp.aplus.enrollment.application.result.EnrollmentCreationResult;
+import com.lxp.aplus.enrollment.application.usecase.EnrollmentCommandUseCase;
+import com.lxp.aplus.enrollment.presentation.request.EnrollmentRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/enrollments")
+public class EnrollmentController {
+
+    private final EnrollmentCommandUseCase enrollmentCommandUseCase;
+
+    @PostMapping
+    public ResponseEntity<ResultResponse<EnrollmentCreationResult>> enroll(
+            @AuthenticationPrincipal Long studentId,
+            @Valid @RequestBody EnrollmentRequest request) {
+
+        EnrollmentCreationResult enrollmentCreationResult = enrollmentCommandUseCase.enroll(request.toCommand(studentId));
+
+        return ResponseEntity.ok(
+                ResultResponse.of(EnrollmentResultCode.ENROLLMENT_SUCCESS, enrollmentCreationResult)
+        );
+    }
+}

--- a/src/main/java/com/lxp/aplus/enrollment/presentation/controller/EnrollmentController.java
+++ b/src/main/java/com/lxp/aplus/enrollment/presentation/controller/EnrollmentController.java
@@ -23,8 +23,9 @@ public class EnrollmentController {
 
     @PostMapping
     public ResponseEntity<ResultResponse<EnrollmentCreationResult>> enroll(
-            @AuthenticationPrincipal Long studentId,
+            //@AuthenticationPrincipal Long studentId,
             @Valid @RequestBody EnrollmentRequest request) {
+        Long studentId = 1L; // TODO: 인증 기능 구현 후 수정 예정
 
         EnrollmentCreationResult enrollmentCreationResult = enrollmentCommandUseCase.enroll(request.toCommand(studentId));
 

--- a/src/main/java/com/lxp/aplus/enrollment/presentation/controller/EnrollmentController.java
+++ b/src/main/java/com/lxp/aplus/enrollment/presentation/controller/EnrollmentController.java
@@ -23,10 +23,8 @@ public class EnrollmentController {
 
     @PostMapping
     public ResponseEntity<ResultResponse<EnrollmentCreationResult>> enroll(
-            //@AuthenticationPrincipal Long studentId,
+            @AuthenticationPrincipal Long studentId,
             @Valid @RequestBody EnrollmentRequest request) {
-        Long studentId = 1L; // TODO: 인증 기능 구현 후 수정 예정
-
         EnrollmentCreationResult enrollmentCreationResult = enrollmentCommandUseCase.enroll(request.toCommand(studentId));
 
         return ResponseEntity.ok(

--- a/src/main/java/com/lxp/aplus/enrollment/presentation/request/EnrollmentRequest.java
+++ b/src/main/java/com/lxp/aplus/enrollment/presentation/request/EnrollmentRequest.java
@@ -4,9 +4,9 @@ import com.lxp.aplus.enrollment.application.command.EnrollmentCommand;
 import jakarta.validation.constraints.NotNull;
 
 public record EnrollmentRequest(
-        @NotNull String impUid,
-        @NotNull String merchantUid,
-        @NotNull Long courseId
+        @NotNull(message = "impUid는 필수입니다.") String impUid,
+        @NotNull(message = "merchantUid는 필수입니다.") String merchantUid,
+        @NotNull(message = "courseId는 필수입니다.") Long courseId
 ) {
     public EnrollmentCommand toCommand(Long studentId) {
         return new EnrollmentCommand(this.impUid, this.merchantUid, studentId, this.courseId);

--- a/src/main/java/com/lxp/aplus/enrollment/presentation/request/EnrollmentRequest.java
+++ b/src/main/java/com/lxp/aplus/enrollment/presentation/request/EnrollmentRequest.java
@@ -1,0 +1,14 @@
+package com.lxp.aplus.enrollment.presentation.request;
+
+import com.lxp.aplus.enrollment.application.command.EnrollmentCommand;
+import jakarta.validation.constraints.NotNull;
+
+public record EnrollmentRequest(
+        @NotNull String impUid,
+        @NotNull String merchantUid,
+        @NotNull Long courseId
+) {
+    public EnrollmentCommand toCommand(Long studentId) {
+        return new EnrollmentCommand(this.impUid, this.merchantUid, studentId, this.courseId);
+    }
+}

--- a/src/test/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentCommandUseCaseTest.java
+++ b/src/test/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentCommandUseCaseTest.java
@@ -1,0 +1,109 @@
+package com.lxp.aplus.enrollment.application.usecase;
+
+import com.lxp.aplus.common.error.BusinessException;
+import com.lxp.aplus.common.error.code.EnrollmentErrorCode;
+import com.lxp.aplus.course.domain.Course;
+import com.lxp.aplus.course.domain.CourseRepository;
+import com.lxp.aplus.enrollment.application.command.EnrollmentCommand;
+import com.lxp.aplus.enrollment.application.result.EnrollmentCreationResult;
+import com.lxp.aplus.enrollment.domain.Enrollment;
+import com.lxp.aplus.enrollment.domain.EnrollmentRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class EnrollmentCommandUseCaseTest {
+
+    @InjectMocks
+    private EnrollmentCommandUseCase enrollmentCommandUseCase;
+
+    @Mock
+    private EnrollmentRepository enrollmentRepository;
+
+    @Mock
+    private CourseRepository courseRepository;
+
+    @Mock
+    private Course course;
+
+    @Captor
+    private ArgumentCaptor<Enrollment> enrollmentCaptor;
+
+    private static final Long STUDENT_ID = 1L;
+    private static final Long COURSE_ID_1 = 100L;
+    private static final String IMP_UID = "imp_1234567890";
+    private static final String MERCHANT_UID = "order_20251203_001";
+
+    @Test
+    @DisplayName("수강 신청이 정상적으로 완료되어야 한다.")
+    void enroll_success() {
+        // given
+        EnrollmentCommand command = new EnrollmentCommand(IMP_UID, MERCHANT_UID, STUDENT_ID, COURSE_ID_1);
+        Enrollment createdEnrollment = Enrollment.of(STUDENT_ID, COURSE_ID_1, LocalDateTime.now().plusYears(2));
+
+        given(courseRepository.findById(COURSE_ID_1)).willReturn(Optional.of(course));
+        given(enrollmentRepository.existsByStudentIdAndCourseId(STUDENT_ID, COURSE_ID_1)).willReturn(false);
+        given(enrollmentRepository.save(any(Enrollment.class))).willReturn(createdEnrollment);
+
+        // when
+        EnrollmentCreationResult result = enrollmentCommandUseCase.enroll(command);
+
+        // then
+        verify(enrollmentRepository).save(enrollmentCaptor.capture());
+        Enrollment capturedEnrollment = enrollmentCaptor.getValue();
+        assertThat(capturedEnrollment.getStudentId()).isEqualTo(STUDENT_ID);
+        assertThat(capturedEnrollment.getCourseId()).isEqualTo(COURSE_ID_1);
+
+        assertThat(result).isNotNull();
+        assertThat(result.totalCount()).isEqualTo(1);
+        assertThat(result.enrollments()).hasSize(1);
+        assertThat(result.enrollments().get(0).studentId()).isEqualTo(STUDENT_ID);
+        assertThat(result.enrollments().get(0).courseId()).isEqualTo(COURSE_ID_1);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 강의를 수강 신청하면 에러가 발생해야 한다.")
+    void enroll_fail_course_not_found() {
+        // given
+        EnrollmentCommand command = new EnrollmentCommand(IMP_UID, MERCHANT_UID, STUDENT_ID, COURSE_ID_1);
+
+        given(courseRepository.findById(COURSE_ID_1)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> enrollmentCommandUseCase.enroll(command))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(EnrollmentErrorCode.ENROLLMENT_COURSE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("이미 수강 중인 강의라면 에러가 발생해야 한다.")
+    void enroll_fail_duplicate() {
+        // given
+        EnrollmentCommand command = new EnrollmentCommand(IMP_UID, MERCHANT_UID, STUDENT_ID, COURSE_ID_1);
+
+        given(courseRepository.findById(COURSE_ID_1)).willReturn(Optional.of(course));
+        given(enrollmentRepository.existsByStudentIdAndCourseId(STUDENT_ID, COURSE_ID_1)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> enrollmentCommandUseCase.enroll(command))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(EnrollmentErrorCode.ALREADY_ENROLLED_COURSE);
+    }
+}

--- a/src/test/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentCommandUseCaseTest.java
+++ b/src/test/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentCommandUseCaseTest.java
@@ -2,9 +2,9 @@ package com.lxp.aplus.enrollment.application.usecase;
 
 import com.lxp.aplus.common.error.BusinessException;
 import com.lxp.aplus.common.error.code.EnrollmentErrorCode;
-import com.lxp.aplus.course.domain.Course;
-import com.lxp.aplus.course.domain.CourseRepository;
 import com.lxp.aplus.enrollment.application.command.EnrollmentCommand;
+import com.lxp.aplus.enrollment.application.port.out.CourseFinder;
+import com.lxp.aplus.enrollment.application.port.out.CourseInfo;
 import com.lxp.aplus.enrollment.application.result.EnrollmentCreationResult;
 import com.lxp.aplus.enrollment.domain.Enrollment;
 import com.lxp.aplus.enrollment.domain.EnrollmentRepository;
@@ -36,10 +36,7 @@ class EnrollmentCommandUseCaseTest {
     private EnrollmentRepository enrollmentRepository;
 
     @Mock
-    private CourseRepository courseRepository;
-
-    @Mock
-    private Course course;
+    private CourseFinder courseFinder;
 
     @Captor
     private ArgumentCaptor<Enrollment> enrollmentCaptor;
@@ -56,7 +53,7 @@ class EnrollmentCommandUseCaseTest {
         EnrollmentCommand command = new EnrollmentCommand(IMP_UID, MERCHANT_UID, STUDENT_ID, COURSE_ID_1);
         Enrollment createdEnrollment = Enrollment.of(STUDENT_ID, COURSE_ID_1, LocalDateTime.now().plusYears(2));
 
-        given(courseRepository.findById(COURSE_ID_1)).willReturn(Optional.of(course));
+        given(courseFinder.findCourseById(COURSE_ID_1)).willReturn(Optional.of(new CourseInfo(COURSE_ID_1)));
         given(enrollmentRepository.existsByStudentIdAndCourseId(STUDENT_ID, COURSE_ID_1)).willReturn(false);
         given(enrollmentRepository.save(any(Enrollment.class))).willReturn(createdEnrollment);
 
@@ -82,7 +79,7 @@ class EnrollmentCommandUseCaseTest {
         // given
         EnrollmentCommand command = new EnrollmentCommand(IMP_UID, MERCHANT_UID, STUDENT_ID, COURSE_ID_1);
 
-        given(courseRepository.findById(COURSE_ID_1)).willReturn(Optional.empty());
+        given(courseFinder.findCourseById(COURSE_ID_1)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> enrollmentCommandUseCase.enroll(command))
@@ -97,7 +94,7 @@ class EnrollmentCommandUseCaseTest {
         // given
         EnrollmentCommand command = new EnrollmentCommand(IMP_UID, MERCHANT_UID, STUDENT_ID, COURSE_ID_1);
 
-        given(courseRepository.findById(COURSE_ID_1)).willReturn(Optional.of(course));
+        given(courseFinder.findCourseById(COURSE_ID_1)).willReturn(Optional.of(new CourseInfo(COURSE_ID_1)));
         given(enrollmentRepository.existsByStudentIdAndCourseId(STUDENT_ID, COURSE_ID_1)).willReturn(true);
 
         // when & then


### PR DESCRIPTION
## ✨ 요약
사용자가 강의를 선택하여 수강 신청을 진행하는 API (POST /api/enrollments)를 구현했습니다. 결제 정보와 함께 요청을 보내면, 비즈니스 로직(중복 검사, 정책 적용)을 거쳐 수강 내역이 생성됩니다.

## 📝 작업 내용
1. Presentation Layer (Controller & DTO)
- EnrollmentController: @AuthenticationPrincipal을 사용하여 로그인한 사용자 ID를 안전하게 주입받도록 구현 (임시 코드 없음)
- DTO: EnrollmentRequest → EnrollmentCommand → EnrollmentCreationResult로 이어지는 계층 간 데이터 변환 로직 캡슐화


2. Business Layer (UseCase)
- EnrollmentCommandUseCase:
  - 중복 검사: existsByStudentIdAndCourseId를 통해 중복 수강 신청 원천 차단
  - 정책 적용: 수강 기간 2년 plusYears(2) 자동 적용 로직 구현
  
3. Infrastructure Layer
- Repository: 도메인 인터페이스(EnrollmentRepository)와 구현체(Impl)를 분리하여 DIP(의존성 역전) 적용

4. Test
- Unit Test: Mockito를 활용한 서비스 계층 단위 테스트(EnrollmentCommandUseCaseTest) 작성 완료

## 💭 주의 사항
- 결제 검증: 실제 PG사 연동 구현체는 결제 담당자와 협의 후 추후 연결할 예정입니다. 
- API 테스트: 현재 컨트롤러가 인증 모듈(@AuthenticationPrincipal)에 의존하고 있어, 로그인 API가 연동되기 전까지는 포스트맨 테스트 시 401 에러가 발생합니다. 로직 검증은 첨부한 단위 테스트 결과를 참고해 주세요.

## 💡 리뷰 포인트
1. DTO 변환 위치 : 컨트롤러에서 변환하지 않고 Request.toCommand() 처럼 DTO 내부에서 변환 메서드를 갖도록 설계했는데, 이 구조가 적절한지 의견 부탁드립니다.
2. Repository 분리: JpaRepository를 바로 쓰지 않고 `EnrollmentRepository` 인터페이스를 둔 구조(DIP)에 대해 피드백 주시면 감사하겠습니다.


## ✅ 테스트
- [x] 로컬 빌드/실행
- [x] 단위 테스트 추가/통과
- [ ] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
<img width="749" height="216" alt="image" src="https://github.com/user-attachments/assets/564d29d6-e501-45b3-b3a9-d96a4e0d7fc8" />
