### PR TITLE
[FEAT] UserCommandUsecase 구현 및 테스트

### DIFF
--- a/src/main/java/com/lxp/aplus/user/application/dto/ActivateUserRequest.java
+++ b/src/main/java/com/lxp/aplus/user/application/dto/ActivateUserRequest.java
@@ -1,0 +1,10 @@
+package com.lxp.aplus.user.application.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ActivateUserRequest(
+        @NotNull(message = "사용자 ID는 필수입니다")
+        Long userId
+) {
+}
+

--- a/src/main/java/com/lxp/aplus/user/application/dto/AddRoleRequest.java
+++ b/src/main/java/com/lxp/aplus/user/application/dto/AddRoleRequest.java
@@ -1,0 +1,14 @@
+package com.lxp.aplus.user.application.dto;
+
+import com.lxp.aplus.user.domain.RoleType;
+import jakarta.validation.constraints.NotNull;
+
+public record AddRoleRequest(
+        @NotNull(message = "사용자 ID는 필수입니다")
+        Long userId,
+
+        @NotNull(message = "역할 타입은 필수입니다")
+        RoleType roleType
+) {
+}
+

--- a/src/main/java/com/lxp/aplus/user/application/dto/ChangePasswordRequest.java
+++ b/src/main/java/com/lxp/aplus/user/application/dto/ChangePasswordRequest.java
@@ -1,0 +1,14 @@
+package com.lxp.aplus.user.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ChangePasswordRequest(
+        @NotNull(message = "사용자 ID는 필수입니다")
+        Long userId,
+
+        @NotBlank(message = "새 비밀번호는 필수입니다")
+        String newPassword
+) {
+}
+

--- a/src/main/java/com/lxp/aplus/user/application/dto/CreateUserRequest.java
+++ b/src/main/java/com/lxp/aplus/user/application/dto/CreateUserRequest.java
@@ -1,0 +1,26 @@
+package com.lxp.aplus.user.application.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record CreateUserRequest(
+        @NotBlank(message = "이름은 필수입니다")
+        String name,
+
+        @NotBlank(message = "닉네임은 필수입니다")
+        String nickName,
+
+        @NotBlank(message = "이메일은 필수입니다")
+        @Email(message = "올바른 이메일 형식이 아닙니다")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수입니다")
+        String password,
+
+        @NotBlank(message = "전화번호는 필수입니다")
+        @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다 (예: 010-1234-5678)")
+        String phoneNumber
+) {
+}
+

--- a/src/main/java/com/lxp/aplus/user/application/dto/DeleteUserRequest.java
+++ b/src/main/java/com/lxp/aplus/user/application/dto/DeleteUserRequest.java
@@ -1,0 +1,10 @@
+package com.lxp.aplus.user.application.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record DeleteUserRequest(
+        @NotNull(message = "사용자 ID는 필수입니다")
+        Long userId
+) {
+}
+

--- a/src/main/java/com/lxp/aplus/user/application/dto/UpdateUserInfoRequest.java
+++ b/src/main/java/com/lxp/aplus/user/application/dto/UpdateUserInfoRequest.java
@@ -1,0 +1,19 @@
+package com.lxp.aplus.user.application.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateUserInfoRequest(
+        @NotNull(message = "사용자 ID는 필수입니다")
+        Long userId,
+
+        @NotBlank(message = "닉네임은 필수입니다")
+        String nickName,
+
+        @NotBlank(message = "이메일은 필수입니다")
+        @Email(message = "올바른 이메일 형식이 아닙니다")
+        String email
+) {
+}
+

--- a/src/main/java/com/lxp/aplus/user/application/dto/UpdateUserStatusRequest.java
+++ b/src/main/java/com/lxp/aplus/user/application/dto/UpdateUserStatusRequest.java
@@ -1,0 +1,14 @@
+package com.lxp.aplus.user.application.dto;
+
+import com.lxp.aplus.user.domain.UserStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateUserStatusRequest(
+        @NotNull(message = "사용자 ID는 필수입니다")
+        Long userId,
+        
+        @NotNull(message = "상태는 필수입니다")
+        UserStatus status
+) {
+}
+

--- a/src/main/java/com/lxp/aplus/user/application/dto/UserResponse.java
+++ b/src/main/java/com/lxp/aplus/user/application/dto/UserResponse.java
@@ -1,0 +1,39 @@
+package com.lxp.aplus.user.application.dto;
+
+import com.lxp.aplus.user.domain.Role;
+import com.lxp.aplus.user.domain.RoleType;
+import com.lxp.aplus.user.domain.User;
+import com.lxp.aplus.user.domain.UserStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record UserResponse(
+        Long id,
+        String name,
+        String nickName,
+        String email,
+        String phoneNumber,
+        UserStatus status,
+        List<RoleType> roles,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static UserResponse from(User user) {
+        return new UserResponse(
+                user.getId(),
+                user.getName(),
+                user.getNickName(),
+                user.getEmail(),
+                user.getPhoneNumber(),
+                user.getStatus(),
+                user.getRoles().stream()
+                        .filter(role -> role.getDeletedAt() == null) // 삭제되지 않은 Role만 포함
+                        .map(Role::getRoleType)
+                        .toList(),
+                user.getCreatedAt(),
+                user.getUpdatedAt()
+        );
+    }
+}
+

--- a/src/main/java/com/lxp/aplus/user/application/dto/WithdrawUserRequest.java
+++ b/src/main/java/com/lxp/aplus/user/application/dto/WithdrawUserRequest.java
@@ -1,0 +1,10 @@
+package com.lxp.aplus.user.application.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record WithdrawUserRequest(
+        @NotNull(message = "사용자 ID는 필수입니다")
+        Long userId
+) {
+}
+

--- a/src/main/java/com/lxp/aplus/user/application/usecase/UserCommandUseCase.java
+++ b/src/main/java/com/lxp/aplus/user/application/usecase/UserCommandUseCase.java
@@ -1,0 +1,97 @@
+package com.lxp.aplus.user.application.usecase;
+
+import com.lxp.aplus.common.error.BusinessException;
+import com.lxp.aplus.user.application.dto.ActivateUserRequest;
+import com.lxp.aplus.user.application.dto.AddRoleRequest;
+import com.lxp.aplus.user.application.dto.ChangePasswordRequest;
+import com.lxp.aplus.user.application.dto.CreateUserRequest;
+import com.lxp.aplus.user.application.dto.DeleteUserRequest;
+import com.lxp.aplus.user.application.dto.UpdateUserInfoRequest;
+import com.lxp.aplus.user.application.dto.UserResponse;
+import com.lxp.aplus.user.application.dto.WithdrawUserRequest;
+import com.lxp.aplus.user.domain.User;
+import com.lxp.aplus.user.domain.UserRepository;
+import com.lxp.aplus.user.domain.exception.UserErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * User 명령(쓰기) UseCase
+ * 
+ * 데이터 변경 작업을 담당.
+ * - @Transactional로 트랜잭션 관리
+ * - 조회는 UserQueryUseCase를 통해 수행
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserCommandUseCase {
+
+    private final UserRepository userRepository;
+    private final UserQueryUseCase userQueryUseCase;
+
+    public UserResponse createUser(CreateUserRequest request) {
+        User user = User.of(
+                request.name(),
+                request.nickName(),
+                request.email(),
+                request.password(),
+                request.phoneNumber()
+        );
+        return UserResponse.from(userRepository.save(user));
+    }
+
+    public UserResponse updateUserInfo(UpdateUserInfoRequest request) {
+        User user = userQueryUseCase.findByIdWithRoles(request.userId())
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+        
+        user.updateUserInfo(request.nickName(), request.email());
+        return UserResponse.from(user);
+    }
+
+    public UserResponse addRole(AddRoleRequest request) {
+        User user = userQueryUseCase.findByIdWithRoles(request.userId())
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        user.addRole(request.roleType());
+        return UserResponse.from(user);
+    }
+
+    public UserResponse withdrawUser(WithdrawUserRequest request) {
+        User user = userQueryUseCase.findByIdWithRoles(request.userId())
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        user.withdraw();
+        return UserResponse.from(user);
+    }
+
+   public UserResponse activateUser(ActivateUserRequest request) {
+        User user = userQueryUseCase.findByIdWithRoles(request.userId())
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        user.activate();
+        return UserResponse.from(user);
+    }
+
+    /**
+     * 비밀번호 변경
+     * 
+     * @param request 비밀번호 변경 요청 (userId, newPassword)
+     */
+    public void changePassword(ChangePasswordRequest request) {
+        User user = userQueryUseCase.findById(request.userId())
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        user.changePassword(request.newPassword());
+    }
+
+    public void deleteUser(DeleteUserRequest request) {
+        // delete() 메서드에서 roles에 접근하므로 roles를 함께 로드해야 함
+        User user = userQueryUseCase.findByIdWithRoles(request.userId())
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        user.delete();
+    }
+}
+

--- a/src/main/java/com/lxp/aplus/user/application/usecase/UserQueryUseCase.java
+++ b/src/main/java/com/lxp/aplus/user/application/usecase/UserQueryUseCase.java
@@ -45,7 +45,7 @@ public class UserQueryUseCase {
      * @return Optional<User>
      */
     Optional<User> findByIdWithRoles(Long id) {
-        return userRepository.findByIdWithRoles(id);
+        return userRepository.findUserWithRolesById(id);
     }
 
     /**
@@ -67,8 +67,8 @@ public class UserQueryUseCase {
      * @param id User ID
      * @return Optional<UserResponse>
      */
-    public Optional<UserResponse> findUserByIdWithRoles(Long id) {
-        return userRepository.findByIdWithRoles(id)
+    public Optional<UserResponse> findUserWithRolesById(Long id) {
+        return userRepository.findUserWithRolesById(id)
                 .map(UserResponse::from);
     }
 

--- a/src/main/java/com/lxp/aplus/user/application/usecase/UserQueryUseCase.java
+++ b/src/main/java/com/lxp/aplus/user/application/usecase/UserQueryUseCase.java
@@ -1,0 +1,85 @@
+package com.lxp.aplus.user.application.usecase;
+
+import com.lxp.aplus.user.application.dto.UserResponse;
+import com.lxp.aplus.user.domain.User;
+import com.lxp.aplus.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * User 조회 UseCase
+ * 
+ * 읽기 전용 작업을 담당.
+ * - @Transactional(readOnly = true)로 성능 최적화
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserQueryUseCase {
+
+    private final UserRepository userRepository;
+
+    /**
+     * ID로 User 조회 (내부용)
+     * 
+     * 같은 패키지(application.usecase) 내에서만 사용 가능.
+     * 외부(Controller 등)에서는 DTO를 반환하는 메서드를 사용해야 함.
+     * 
+     * @param id User ID
+     * @return Optional<User>
+     */
+    Optional<User> findById(Long id) {
+        return userRepository.findById(id);
+    }
+
+    /**
+     * ID로 User와 Role을 함께 조회 (내부용)
+     * 
+     * 같은 패키지(application.usecase) 내에서만 사용 가능.
+     * roles를 확인해야 하는 경우 사용 (예: addRole)
+     * 
+     * @param id User ID
+     * @return Optional<User>
+     */
+    Optional<User> findByIdWithRoles(Long id) {
+        return userRepository.findByIdWithRoles(id);
+    }
+
+    /**
+     * ID로 User 조회 (외부용 - DTO 반환)
+     * 
+     * @param id User ID
+     * @return Optional<UserResponse>
+     */
+    public Optional<UserResponse> findUserById(Long id) {
+        return findById(id)
+                .map(UserResponse::from);
+    }
+
+    /**
+     * ID로 User와 Role을 함께 조회 (외부용 - DTO 반환)
+     * 
+     * Fetch Join을 사용하여 N+1 문제를 방지합니다.
+     * 
+     * @param id User ID
+     * @return Optional<UserResponse>
+     */
+    public Optional<UserResponse> findUserByIdWithRoles(Long id) {
+        return userRepository.findByIdWithRoles(id)
+                .map(UserResponse::from);
+    }
+
+    /**
+     * User 존재 여부 확인
+     * 
+     * @param id User ID
+     * @return 존재 여부
+     */
+    public boolean existsById(Long id) {
+        return userRepository.existsById(id);
+    }
+}
+

--- a/src/main/java/com/lxp/aplus/user/application/usecase/usecase-overview.md
+++ b/src/main/java/com/lxp/aplus/user/application/usecase/usecase-overview.md
@@ -1,0 +1,290 @@
+# User UseCase 구조 설계
+
+## 구조
+
+### Application Layer
+
+- **UserQueryUseCase** (읽기)
+  - 데이터 조회 작업 담당
+  - `@Transactional(readOnly = true)` (읽기 전용 트랜잭션)
+  - `findUserById`, `findUserByIdWithRoles`, `existsById` 등
+
+## CQRS 패턴
+
+### Query (읽기)
+- 데이터 조회 작업
+- `@Transactional(readOnly = true)` 사용
+- 예: 조회, 검색
+
+### 분리 이유
+- 읽기/쓰기 책임 분리
+- 성능 최적화 (readOnly 트랜잭션)
+- 확장성 향상
+
+## 트랜잭션 관리
+
+### Query UseCase
+```java
+@Transactional(readOnly = true)  // 읽기 전용 트랜잭션
+public class UserQueryUseCase {
+    // 데이터 조회 작업
+}
+```
+
+### 트랜잭션이 필요한 이유
+1. **Lazy Loading 지원**: 연관관계 접근 시 프록시 초기화를 위해 DB 연결 필요
+2. **일관성 있는 읽기**: 같은 트랜잭션 내에서 일관된 데이터 스냅샷 보장
+3. **성능 최적화**: `readOnly = true`는 DB에 읽기 전용 힌트 제공
+
+## 영속성 컨텍스트 (Persistence Context)
+
+### 개념
+- 엔티티를 메모리에 보관하는 저장소 (1차 캐시)
+- 트랜잭션 범위 내에서만 존재
+- 같은 ID의 엔티티는 하나만 관리
+
+### 동작 방식
+```
+1. 조회 시
+   - DB에서 조회 → 영속성 컨텍스트에 저장 + 스냅샷 생성
+
+2. 재조회 시
+   - 영속성 컨텍스트에서 가져옴 (DB 조회 안 함)
+
+3. 커밋 시
+   - 읽기 전용이므로 변경 감지 없음
+```
+
+### 스냅샷 (Snapshot)
+- 엔티티의 원본 상태를 저장 (변경 감지용)
+- 조회 시점의 상태를 복사하여 저장
+- 읽기 전용 트랜잭션에서는 변경 감지 불필요
+
+## 프록시 (Proxy)와 Lazy Loading
+
+### 프록시
+- 실제 데이터 대신 사용되는 가짜 객체
+- 연관관계 필드에 사용 (`@OneToMany(fetch = FetchType.LAZY)`)
+
+### Lazy Loading 동작
+```java
+// 1. User 조회
+User user = repository.findById(1L).get();
+// user.roles = PersistentBag (프록시) ← 실제 데이터 없음
+
+// 2. roles 접근 시 프록시 초기화
+List<Role> roles = user.getRoles();
+// SQL: SELECT * FROM roles WHERE user_id = 1
+// 프록시 → 실제 List<Role>로 변환
+```
+
+### 트랜잭션과 프록시
+- **트랜잭션 내**: 프록시 초기화 가능 (DB 연결 살아있음)
+- **트랜잭션 밖**: `LazyInitializationException` 발생
+
+### EAGER vs LAZY
+| 구분 | LAZY | EAGER |
+|------|------|-------|
+| 프록시 사용 | 사용 | 사용 안 함 |
+| 조회 시점 | 접근 시 | 즉시 |
+| 트랜잭션 필요 | 필요 | 불필요 (이미 로딩됨) |
+
+## 캐싱
+
+### 영속성 컨텍스트 (1차 캐시)
+- 트랜잭션 내에서 같은 ID의 엔티티는 한 번만 조회
+- 재조회 시 DB 조회 없이 영속성 컨텍스트에서 반환
+
+```java
+@Transactional(readOnly = true)
+public void test() {
+    User user1 = repository.findById(1L).get();
+    // SQL: SELECT * FROM users WHERE id = 1
+    
+    User user2 = repository.findById(1L).get();
+    // SQL 실행 안 함! ← 영속성 컨텍스트에서 가져옴
+    // user1 == user2 (같은 객체)
+}
+```
+
+### 주의사항
+- 영속성 컨텍스트는 트랜잭션 범위 내에서만 유효
+- 트랜잭션 종료 시 영속성 컨텍스트도 종료
+- 이후 엔티티 접근 시 LazyInitializationException 가능
+
+## UseCase 사용 예시
+
+### Query UseCase
+```java
+@Autowired
+private UserQueryUseCase userQueryUseCase;
+
+// User 조회 (DTO 반환)
+Optional<UserResponse> user = userQueryUseCase.findUserById(1L);
+
+// User와 Role 함께 조회 (DTO 반환)
+Optional<UserResponse> userWithRoles = userQueryUseCase.findUserByIdWithRoles(1L);
+
+// User 존재 여부 확인
+boolean exists = userQueryUseCase.existsById(1L);
+```
+
+## 주의사항
+
+### 1. 트랜잭션 범위
+- UseCase 메서드는 트랜잭션 내에서 실행됨
+- 엔티티를 반환할 경우, 트랜잭션 밖에서 Lazy Loading 접근 시 주의
+
+### 2. DTO 변환 권장
+- 엔티티 직접 반환보다 DTO로 변환하여 반환 권장
+- 트랜잭션 내에서 DTO로 변환하면 Lazy Loading 안전
+
+```java
+@Transactional(readOnly = true)
+public Optional<UserResponse> findUserById(Long id) {
+    return userRepository.findById(id)
+            .map(UserResponse::from);  // 트랜잭션 내에서 변환
+}
+```
+
+### 3. 조인 조회 (Fetch Join)
+
+연관관계를 함께 조회해야 할 경우 Fetch Join을 사용하여 N+1 문제를 방지하고 성능을 최적화한다.
+
+#### N+1 문제
+
+```java
+// ❌ N+1 문제 발생
+User user = repository.findById(1L).get();
+List<Role> roles = user.getRoles(); // 추가 쿼리 발생
+// SQL 1: SELECT * FROM users WHERE id = 1
+// SQL 2: SELECT * FROM roles WHERE user_id = 1
+```
+
+**문제점:**
+- User 1개 조회 시 Role 조회를 위한 추가 쿼리 발생
+- 여러 User 조회 시 쿼리 수가 급증 (1 + N)
+
+#### Fetch Join 해결 방법
+
+**방법 1: @EntityGraph 사용 (현재 구현)**
+
+```java
+// UserJpaRepository.java
+@EntityGraph(attributePaths = {"roles"})
+Optional<User> findByIdWithRoles(Long id);
+```
+
+**장점:**
+- `@Query` 어노테이션 없이 간단하게 구현
+- Spring Data JPA가 자동으로 LEFT JOIN FETCH 쿼리 생성
+- 가독성 좋음
+
+**생성되는 SQL:**
+```sql
+SELECT u.*, r.*
+FROM users u
+LEFT JOIN roles r ON u.id = r.user_id
+WHERE u.id = ?
+```
+
+**방법 2: @Query 사용**
+
+```java
+@Query("SELECT DISTINCT u FROM User u LEFT JOIN FETCH u.roles WHERE u.id = :id")
+Optional<User> findByIdWithRoles(@Param("id") Long id);
+```
+
+**장점:**
+- 쿼리를 직접 제어 가능
+- 복잡한 조인 조건 추가 가능
+
+**단점:**
+- 쿼리 문자열 관리 필요
+- 오타 위험
+
+#### 구현 구조
+
+```
+UserQueryUseCase
+  ↓
+UserRepository (도메인 인터페이스)
+  ↓
+UserRepositoryImpl (구현체)
+  ↓
+UserJpaRepository (Spring Data JPA)
+  ↓
+@EntityGraph(attributePaths = {"roles"})
+```
+
+**코드 흐름:**
+
+1. **도메인 인터페이스 정의**
+```java
+// UserRepository.java
+public interface UserRepository {
+    Optional<User> findByIdWithRoles(Long id);
+}
+```
+
+2. **Spring Data JPA 메서드 정의**
+```java
+// UserJpaRepository.java
+@EntityGraph(attributePaths = {"roles"})
+Optional<User> findByIdWithRoles(Long id);
+```
+
+3. **구현체에서 위임**
+```java
+// UserRepositoryImpl.java
+public Optional<User> findByIdWithRoles(Long id) {
+    return jpaRepository.findByIdWithRoles(id);
+}
+```
+
+4. **UseCase에서 사용**
+```java
+// UserQueryUseCase.java
+public Optional<UserResponse> findUserByIdWithRoles(Long id) {
+    return userRepository.findByIdWithRoles(id)
+            .map(UserResponse::from);
+}
+```
+
+#### 사용 시점
+
+**findById() vs findByIdWithRoles()**
+
+```java
+// ❌ roles가 필요 없는 경우
+Optional<UserResponse> user = userQueryUseCase.findUserById(1L);
+// SQL: SELECT * FROM users WHERE id = 1
+
+// ✅ roles가 필요한 경우
+Optional<UserResponse> userWithRoles = userQueryUseCase.findUserByIdWithRoles(1L);
+// SQL: SELECT u.*, r.* FROM users u LEFT JOIN roles r ON u.id = r.user_id WHERE u.id = 1
+```
+
+**선택 기준:**
+- `findUserById()`: User 정보만 필요한 경우
+- `findUserByIdWithRoles()`: Role 정보도 함께 필요한 경우 (DTO 변환 시 roles 필드 사용)
+
+#### 주의사항
+
+1. **DISTINCT 사용**
+   - Fetch Join 시 중복 데이터 발생 가능
+   - `@Query` 사용 시 `DISTINCT` 명시 권장
+   - `@EntityGraph`는 Spring Data JPA가 자동 처리
+
+2. **페이징 제한**
+   - Fetch Join과 페이징을 함께 사용하면 문제 발생 가능
+   - 페이징이 필요한 경우 별도 전략 필요
+
+3. **성능 고려**
+   - 필요한 경우에만 Fetch Join 사용
+   - 불필요한 연관관계 로딩은 성능 저하 원인
+
+### 4. Package-private 메서드
+- `findById()`, `findByIdWithRoles()`는 package-private으로 설계
+- 같은 패키지 내에서만 사용 가능 (내부 UseCase 간 통신용)
+- 외부(Controller 등)에서는 public 메서드(`findUserById`, `findUserByIdWithRoles`) 사용

--- a/src/main/java/com/lxp/aplus/user/domain/User.java
+++ b/src/main/java/com/lxp/aplus/user/domain/User.java
@@ -1,6 +1,8 @@
 package com.lxp.aplus.user.domain;
 
 import com.lxp.aplus.common.domain.BaseAggregateRoot;
+import com.lxp.aplus.common.error.BusinessException;
+import com.lxp.aplus.user.domain.exception.UserErrorCode;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -50,11 +52,13 @@ public class User extends BaseAggregateRoot {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    public static User of(String name, String email, String password) {
+    public static User of(String name, String nickName, String email, String password, String phoneNumber) {
         User user = User.builder()
                 .name(name)
+                .nickName(nickName)
                 .email(email)
                 .password(password)
+                .phoneNumber(phoneNumber)
                 .build();
 
         user.addRole(RoleType.STUDENT);
@@ -62,6 +66,14 @@ public class User extends BaseAggregateRoot {
     }
 
     public void addRole(RoleType roleType) {
+        // 이미 존재하는 역할인지 확인
+        boolean alreadyExists = this.roles.stream()
+                .anyMatch(role -> role.getRoleType() == roleType && role.getDeletedAt() == null);
+        
+        if (alreadyExists) {
+            throw new BusinessException(UserErrorCode.ROLE_ALREADY_EXISTS);
+        }
+        
         Role role = Role.of(this.id, roleType);
         this.roles.add(role);
     }
@@ -71,8 +83,30 @@ public class User extends BaseAggregateRoot {
         this.email = email;
     }
 
-    // TODO : 상태값에 따른 비즈니스 로직은 서비스 레이어에서 처리
-    public void updateStatus(UserStatus status) {
+    /**
+     * 사용자 탈퇴 처리
+     * 상태를 WITHDRAWN으로 변경
+     */
+    public void withdraw() {
+        this.status = UserStatus.WITHDRAWN;
+    }
+
+    /**
+     * 휴면 해제 처리
+     * 상태를 INACTIVE에서 ACTIVE로 변경
+     */
+    public void activate() {
+        if (this.status != UserStatus.INACTIVE)
+            throw new BusinessException(UserErrorCode.INVALID_STATUS_TRANSITION);
+
+        this.status = UserStatus.ACTIVE;
+    }
+
+    /**
+     * 상태 변경 (내부용)
+     * 내부 비즈니스 로직에서만 사용
+     */
+    void updateStatus(UserStatus status) {
         this.status = status;
     }
 
@@ -83,6 +117,10 @@ public class User extends BaseAggregateRoot {
 
     public void delete() {
         this.deletedAt = LocalDateTime.now();
+        // 연관된 Role들도 모두 soft delete
+        this.roles.stream()
+                .filter(role -> role.getDeletedAt() == null) // 아직 삭제되지 않은 Role만
+                .forEach(Role::delete);
     }
 
 }

--- a/src/main/java/com/lxp/aplus/user/domain/UserRepository.java
+++ b/src/main/java/com/lxp/aplus/user/domain/UserRepository.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 public interface UserRepository {
     User save(User user);
     Optional<User> findById(Long id);
-    Optional<User> findByIdWithRoles(Long id);
+    Optional<User> findUserWithRolesById(Long id);
     boolean existsById(Long id);
 }
 

--- a/src/main/java/com/lxp/aplus/user/domain/UserRepository.java
+++ b/src/main/java/com/lxp/aplus/user/domain/UserRepository.java
@@ -5,5 +5,7 @@ import java.util.Optional;
 public interface UserRepository {
     User save(User user);
     Optional<User> findById(Long id);
+    Optional<User> findByIdWithRoles(Long id);
+    boolean existsById(Long id);
 }
 

--- a/src/main/java/com/lxp/aplus/user/domain/exception/UserErrorCode.java
+++ b/src/main/java/com/lxp/aplus/user/domain/exception/UserErrorCode.java
@@ -1,0 +1,19 @@
+package com.lxp.aplus.user.domain.exception;
+
+import com.lxp.aplus.common.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "EU001", "사용자를 찾을 수 없습니다."),
+    ROLE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "EU002", "이미 존재하는 역할입니다."),
+    INVALID_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "EU003", "유효하지 않은 상태 변경입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}
+

--- a/src/main/java/com/lxp/aplus/user/infrastructure/persistence/UserJpaRepository.java
+++ b/src/main/java/com/lxp/aplus/user/infrastructure/persistence/UserJpaRepository.java
@@ -2,7 +2,10 @@ package com.lxp.aplus.user.infrastructure.persistence;
 
 import com.lxp.aplus.user.domain.User;
 import com.lxp.aplus.user.domain.UserRepository;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 /**
  * Spring Data JPA Repository
@@ -30,5 +33,18 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * @see UserRepositoryImpl
  */
 public interface UserJpaRepository extends JpaRepository<User, Long> {
+    
+    /**
+     * User와 Role을 함께 조회 (Fetch Join)
+     * 
+     * @EntityGraph를 사용하여 @Query 없이 Fetch Join 수행
+     * - attributePaths = {"roles"}로 roles 연관관계를 즉시 로딩
+     * - Spring Data JPA가 자동으로 LEFT JOIN FETCH 쿼리 생성
+     * 
+     * @param id User ID
+     * @return Optional<User>
+     */
+    @EntityGraph(attributePaths = {"roles"})
+    Optional<User> findByIdWithRoles(Long id);
 }
 

--- a/src/main/java/com/lxp/aplus/user/infrastructure/persistence/UserJpaRepository.java
+++ b/src/main/java/com/lxp/aplus/user/infrastructure/persistence/UserJpaRepository.java
@@ -37,14 +37,15 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
     /**
      * User와 Role을 함께 조회 (Fetch Join)
      * 
-     * @EntityGraph를 사용하여 @Query 없이 Fetch Join 수행
+     * @EntityGraph를 사용하여 Fetch Join 수행
      * - attributePaths = {"roles"}로 roles 연관관계를 즉시 로딩
      * - Spring Data JPA가 자동으로 LEFT JOIN FETCH 쿼리 생성
+     * - 메서드 이름 구조에 따라 파싱 결과가 달라질 수 있음
      * 
      * @param id User ID
      * @return Optional<User>
      */
     @EntityGraph(attributePaths = {"roles"})
-    Optional<User> findByIdWithRoles(Long id);
+    Optional<User> getWithRolesById(Long id);
 }
 

--- a/src/main/java/com/lxp/aplus/user/infrastructure/persistence/UserRepositoryImpl.java
+++ b/src/main/java/com/lxp/aplus/user/infrastructure/persistence/UserRepositoryImpl.java
@@ -52,8 +52,8 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
-    public Optional<User> findByIdWithRoles(Long id) {
-        return jpaRepository.findByIdWithRoles(id);
+    public Optional<User> findUserWithRolesById(Long id) {
+        return jpaRepository.getWithRolesById(id);
     }
 
     @Override

--- a/src/main/java/com/lxp/aplus/user/infrastructure/persistence/UserRepositoryImpl.java
+++ b/src/main/java/com/lxp/aplus/user/infrastructure/persistence/UserRepositoryImpl.java
@@ -51,5 +51,15 @@ public class UserRepositoryImpl implements UserRepository {
         return jpaRepository.findById(id);
     }
 
+    @Override
+    public Optional<User> findByIdWithRoles(Long id) {
+        return jpaRepository.findByIdWithRoles(id);
+    }
+
+    @Override
+    public boolean existsById(Long id) {
+        return jpaRepository.existsById(id);
+    }
+
 }
 

--- a/src/test/java/com/lxp/aplus/user/application/usecase/UserCommandUseCaseTest.java
+++ b/src/test/java/com/lxp/aplus/user/application/usecase/UserCommandUseCaseTest.java
@@ -1,0 +1,250 @@
+package com.lxp.aplus.user.application.usecase;
+
+import com.lxp.aplus.common.error.BusinessException;
+import com.lxp.aplus.user.application.dto.*;
+import com.lxp.aplus.user.domain.RoleType;
+import com.lxp.aplus.user.domain.User;
+import com.lxp.aplus.user.domain.UserRepository;
+import com.lxp.aplus.user.domain.UserStatus;
+import com.lxp.aplus.user.domain.exception.UserErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserCommandUseCase 테스트")
+class UserCommandUseCaseTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserQueryUseCase userQueryUseCase;
+
+    @InjectMocks
+    private UserCommandUseCase userCommandUseCase;
+
+    @Test
+    @DisplayName("User를 생성할 수 있다")
+    void createUser() {
+        // given
+        CreateUserRequest request = new CreateUserRequest(
+                "홍길동",
+                "hong",
+                "hong@example.com",
+                "password123",
+                "010-1234-5678"
+        );
+        
+        User savedUser = User.of("홍길동", "hong", "hong@example.com", "password123", "010-1234-5678");
+        when(userRepository.save(any(User.class))).thenReturn(savedUser);
+
+        // when
+        UserResponse response = userCommandUseCase.createUser(request);
+
+        // then
+        assertThat(response.name()).isEqualTo("홍길동");
+        assertThat(response.nickName()).isEqualTo("hong");
+        assertThat(response.email()).isEqualTo("hong@example.com");
+        assertThat(response.phoneNumber()).isEqualTo("010-1234-5678");
+        assertThat(response.status()).isEqualTo(UserStatus.PENDING);
+        assertThat(response.roles()).hasSize(1);
+        assertThat(response.roles().get(0)).isEqualTo(RoleType.STUDENT);
+        verify(userRepository, times(1)).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("User 정보를 업데이트할 수 있다")
+    void updateUserInfo() {
+        // given
+        Long userId = 1L;
+        User user = User.of("홍길동", "hong", "hong@example.com", "password123", "010-1234-5678");
+        
+        UpdateUserInfoRequest request = new UpdateUserInfoRequest(
+                userId,
+                "hongUpdated",
+                "hong.updated@example.com"
+        );
+        
+        when(userQueryUseCase.findByIdWithRoles(userId)).thenReturn(Optional.of(user));
+
+        // when
+        UserResponse response = userCommandUseCase.updateUserInfo(request);
+
+        // then
+        assertThat(response.nickName()).isEqualTo("hongUpdated");
+        assertThat(response.email()).isEqualTo("hong.updated@example.com");
+        assertThat(response.name()).isEqualTo("홍길동"); // 변경되지 않음
+        verify(userQueryUseCase, times(1)).findByIdWithRoles(userId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 User 정보 업데이트 시 예외가 발생한다")
+    void updateUserInfo_NotFound() {
+        // given
+        UpdateUserInfoRequest request = new UpdateUserInfoRequest(
+                999L,
+                "hongUpdated",
+                "hong.updated@example.com"
+        );
+        
+        when(userQueryUseCase.findByIdWithRoles(999L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userCommandUseCase.updateUserInfo(request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(UserErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("User에 Role을 추가할 수 있다")
+    void addRole() {
+        // given
+        Long userId = 1L;
+        User user = User.of("홍길동", "hong", "hong@example.com", "password123", "010-1234-5678");
+        
+        AddRoleRequest request = new AddRoleRequest(userId, RoleType.ADMIN);
+        
+        when(userQueryUseCase.findByIdWithRoles(userId)).thenReturn(Optional.of(user));
+
+        // when
+        UserResponse response = userCommandUseCase.addRole(request);
+
+        // then
+        assertThat(response.roles()).hasSize(2);
+        assertThat(response.roles()).contains(RoleType.STUDENT, RoleType.ADMIN);
+        verify(userQueryUseCase, times(1)).findByIdWithRoles(userId);
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 Role 추가 시 예외가 발생한다")
+    void addRole_AlreadyExists() {
+        // given
+        Long userId = 1L;
+        User user = User.of("홍길동", "hong", "hong@example.com", "password123", "010-1234-5678");
+        user.addRole(RoleType.ADMIN);
+        
+        AddRoleRequest request = new AddRoleRequest(userId, RoleType.ADMIN);
+        
+        when(userQueryUseCase.findByIdWithRoles(userId))
+                .thenReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> userCommandUseCase.addRole(request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(UserErrorCode.ROLE_ALREADY_EXISTS);
+    }
+
+    @Test
+    @DisplayName("User를 탈퇴 처리할 수 있다")
+    void withdrawUser() {
+        // given
+        Long userId = 1L;
+        User user = User.of("홍길동", "hong", "hong@example.com", "password123", "010-1234-5678");
+        
+        WithdrawUserRequest request = new WithdrawUserRequest(userId);
+        
+        when(userQueryUseCase.findByIdWithRoles(userId)).thenReturn(Optional.of(user));
+
+        // when
+        UserResponse response = userCommandUseCase.withdrawUser(request);
+
+        // then
+        assertThat(response.status()).isEqualTo(UserStatus.WITHDRAWN);
+        verify(userQueryUseCase, times(1)).findByIdWithRoles(userId);
+    }
+
+    @Test
+    @DisplayName("User를 활성화할 수 있다")
+    void activateUser() {
+        // given
+        Long userId = 1L;
+        User user = User.builder()
+                .name("홍길동")
+                .nickName("hong")
+                .email("hong@example.com")
+                .password("password123")
+                .phoneNumber("010-1234-5678")
+                .status(UserStatus.INACTIVE)
+                .build();
+        
+        ActivateUserRequest request = new ActivateUserRequest(userId);
+        
+        when(userQueryUseCase.findByIdWithRoles(userId)).thenReturn(Optional.of(user));
+
+        // when
+        UserResponse response = userCommandUseCase.activateUser(request);
+
+        // then
+        assertThat(response.status()).isEqualTo(UserStatus.ACTIVE);
+        verify(userQueryUseCase, times(1)).findByIdWithRoles(userId);
+    }
+
+    @Test
+    @DisplayName("INACTIVE가 아닌 상태에서 활성화 시 예외가 발생한다")
+    void activateUser_InvalidStatus() {
+        // given
+        Long userId = 1L;
+        User user = User.of("홍길동", "hong", "hong@example.com", "password123", "010-1234-5678");
+        
+        ActivateUserRequest request = new ActivateUserRequest(userId);
+        
+        when(userQueryUseCase.findByIdWithRoles(userId)).thenReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> userCommandUseCase.activateUser(request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(UserErrorCode.INVALID_STATUS_TRANSITION);
+    }
+
+    @Test
+    @DisplayName("User 비밀번호를 변경할 수 있다")
+    void changePassword() {
+        // given
+        Long userId = 1L;
+        User user = User.of("홍길동", "hong", "hong@example.com", "password123", "010-1234-5678");
+        
+        ChangePasswordRequest request = new ChangePasswordRequest(userId, "newPassword123");
+        
+        when(userQueryUseCase.findById(userId)).thenReturn(Optional.of(user));
+
+        // when
+        userCommandUseCase.changePassword(request);
+
+        // then
+        verify(userQueryUseCase, times(1)).findById(userId);
+    }
+
+    @Test
+    @DisplayName("User를 삭제할 수 있다")
+    void deleteUser() {
+        // given
+        Long userId = 1L;
+        User user = User.of("홍길동", "hong", "hong@example.com", "password123", "010-1234-5678");
+        user.addRole(RoleType.ADMIN);
+        
+        DeleteUserRequest request = new DeleteUserRequest(userId);
+        
+        when(userQueryUseCase.findByIdWithRoles(userId)).thenReturn(Optional.of(user));
+
+        // when
+        userCommandUseCase.deleteUser(request);
+
+        // then
+        verify(userQueryUseCase, times(1)).findByIdWithRoles(userId);
+    }
+}
+

--- a/src/test/java/com/lxp/aplus/user/application/usecase/UserQueryUseCaseTest.java
+++ b/src/test/java/com/lxp/aplus/user/application/usecase/UserQueryUseCaseTest.java
@@ -68,17 +68,17 @@ class UserQueryUseCaseTest {
 
     @Test
     @DisplayName("ID로 User와 Role을 함께 조회할 수 있다")
-    void findUserByIdWithRoles() {
+    void findUserWithRolesById() {
         // given
         Long userId = 1L;
         User user = User.of("홍길동", "hong", "hong@example.com", "password123", "010-1234-5678");
         user.addRole(RoleType.INSTRUCTOR);
         user.addRole(RoleType.ADMIN);
         
-        when(userRepository.findByIdWithRoles(userId)).thenReturn(Optional.of(user));
+        when(userRepository.findUserWithRolesById(userId)).thenReturn(Optional.of(user));
 
         // when
-        Optional<UserResponse> response = userQueryUseCase.findUserByIdWithRoles(userId);
+        Optional<UserResponse> response = userQueryUseCase.findUserWithRolesById(userId);
 
         // then
         assertThat(response).isPresent();
@@ -88,14 +88,14 @@ class UserQueryUseCaseTest {
                 RoleType.INSTRUCTOR,
                 RoleType.ADMIN
         );
-        verify(userRepository, times(1)).findByIdWithRoles(userId);
+        verify(userRepository, times(1)).findUserWithRolesById(userId);
     }
 
     @Test
     @DisplayName("존재하지 않는 User와 Role 조회 시 Optional.empty()를 반환한다")
     void findUserByIdWithRoles_NotFound() {
         // when
-        Optional<UserResponse> response = userQueryUseCase.findUserByIdWithRoles(999L);
+        Optional<UserResponse> response = userQueryUseCase.findUserWithRolesById(999L);
 
         // then
         assertThat(response).isEmpty();

--- a/src/test/java/com/lxp/aplus/user/application/usecase/UserQueryUseCaseTest.java
+++ b/src/test/java/com/lxp/aplus/user/application/usecase/UserQueryUseCaseTest.java
@@ -1,0 +1,125 @@
+package com.lxp.aplus.user.application.usecase;
+
+import com.lxp.aplus.user.application.dto.UserResponse;
+import com.lxp.aplus.user.domain.Role;
+import com.lxp.aplus.user.domain.RoleType;
+import com.lxp.aplus.user.domain.User;
+import com.lxp.aplus.user.domain.UserRepository;
+import com.lxp.aplus.user.domain.UserStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserQueryUseCase 테스트")
+class UserQueryUseCaseTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserQueryUseCase userQueryUseCase;
+
+    @Test
+    @DisplayName("ID로 User를 조회할 수 있다")
+    void findUserById() {
+        // given
+        Long userId = 1L;
+        User user = User.of("홍길동", "hong", "hong@example.com", "password123", "010-1234-5678");
+        
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        // when
+        Optional<UserResponse> response = userQueryUseCase.findUserById(userId);
+
+        // then
+        assertThat(response).isPresent();
+        assertThat(response.get().name()).isEqualTo("홍길동");
+        assertThat(response.get().nickName()).isEqualTo("hong");
+        assertThat(response.get().email()).isEqualTo("hong@example.com");
+        assertThat(response.get().phoneNumber()).isEqualTo("010-1234-5678");
+        assertThat(response.get().status()).isEqualTo(UserStatus.PENDING);
+        assertThat(response.get().roles()).hasSize(1);
+        assertThat(response.get().roles().get(0)).isEqualTo(RoleType.STUDENT);
+        verify(userRepository, times(1)).findById(userId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 User 조회 시 Optional.empty()를 반환한다")
+    void findUserById_NotFound() {
+        // given
+        Long notExistUserId = 999L;
+
+        when(userRepository.findById(notExistUserId)).thenReturn(Optional.empty());
+        // when
+        Optional<UserResponse> response = userQueryUseCase.findUserById(notExistUserId);
+
+        // then
+        assertThat(response).isEmpty();
+    }
+
+    @Test
+    @DisplayName("ID로 User와 Role을 함께 조회할 수 있다")
+    void findUserByIdWithRoles() {
+        // given
+        Long userId = 1L;
+        User user = User.of("홍길동", "hong", "hong@example.com", "password123", "010-1234-5678");
+        user.addRole(RoleType.INSTRUCTOR);
+        user.addRole(RoleType.ADMIN);
+        
+        when(userRepository.findByIdWithRoles(userId)).thenReturn(Optional.of(user));
+
+        // when
+        Optional<UserResponse> response = userQueryUseCase.findUserByIdWithRoles(userId);
+
+        // then
+        assertThat(response).isPresent();
+        assertThat(response.get().roles()).hasSize(3);
+        assertThat(response.get().roles()).containsExactlyInAnyOrder(
+                RoleType.STUDENT,
+                RoleType.INSTRUCTOR,
+                RoleType.ADMIN
+        );
+        verify(userRepository, times(1)).findByIdWithRoles(userId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 User와 Role 조회 시 Optional.empty()를 반환한다")
+    void findUserByIdWithRoles_NotFound() {
+        // when
+        Optional<UserResponse> response = userQueryUseCase.findUserByIdWithRoles(999L);
+
+        // then
+        assertThat(response).isEmpty();
+    }
+
+    @Test
+    @DisplayName("User 존재 여부를 확인할 수 있다")
+    void existsById() {
+        // given
+        Long userId = 1L;
+        Long notExistUserId = 999L;
+        
+        when(userRepository.existsById(userId)).thenReturn(true);
+        when(userRepository.existsById(notExistUserId)).thenReturn(false);
+
+        // when
+        boolean exists = userQueryUseCase.existsById(userId);
+        boolean notExists = userQueryUseCase.existsById(notExistUserId);
+
+        // then
+        assertThat(exists).isTrue();
+        assertThat(notExists).isFalse();
+        verify(userRepository, times(1)).existsById(userId);
+        verify(userRepository, times(1)).existsById(notExistUserId);
+    }
+}
+

--- a/src/test/java/com/lxp/aplus/user/application/usecase/usecase-test-overview.md
+++ b/src/test/java/com/lxp/aplus/user/application/usecase/usecase-test-overview.md
@@ -1,0 +1,292 @@
+# UseCase 테스트 개요
+
+## 목적
+
+UseCase 레이어의 비즈니스 로직을 격리된 환경에서 테스트하여, 빠르고 안정적인 단위 테스트를 수행한다.
+
+## 테스트 전략
+
+### Mock 기반 격리 테스트
+
+UseCase 테스트는 **Mock 객체**를 사용하여 의존성을 격리한다.
+
+#### 장점
+
+1. **빠른 실행 속도**
+   - 실제 DB 접근 없이 메모리에서만 실행
+   - 통합 테스트 대비 빠른 실행 속도
+
+2. **완전한 격리**
+   - 다른 테스트와 독립적으로 실행
+   - 외부 의존성(DB, 네트워크 등)의 영향 없음
+   - 테스트 간 상호 간섭 없음
+
+3. **단위 테스트 집중**
+   - UseCase의 비즈니스 로직만 집중 테스트
+   - Repository나 Infrastructure 레이어의 버그와 분리
+
+4. **유연한 시나리오 테스트**
+   - 다양한 예외 상황을 쉽게 시뮬레이션
+   - 실제로 발생하기 어려운 엣지 케이스 테스트 가능
+
+### 테스트 구조
+
+#### 기본 설정
+
+```java
+@ExtendWith(MockitoExtension.class)
+class UserQueryUseCaseTest {
+    @Mock
+    private UserRepository userRepository;
+    
+    @InjectMocks
+    private UserQueryUseCase userQueryUseCase;
+}
+```
+
+**어노테이션 설명:**
+- `@ExtendWith(MockitoExtension.class)`: Mockito 확장 기능 활성화
+- `@Mock`: Mock 객체 생성 (의존성 주입용)
+- `@InjectMocks`: Mock을 주입받을 대상 객체 생성
+
+**의존성 Mock:**
+- Repository 계층: 데이터 조회 Mock
+
+## 테스트 작성 원칙
+
+### 1. Public API만 사용
+
+**❌ 나쁜 예:**
+```java
+// package-private 메서드 직접 호출
+userQueryUseCase.findById(userId); // package-private 메서드
+```
+
+**✅ 좋은 예:**
+```java
+// public 메서드 사용
+Optional<UserResponse> response = userQueryUseCase.findUserById(userId);
+```
+
+**이유:**
+- UseCase 설계 의도 유지 (캡슐화)
+- 테스트만을 위해 접근 제어자 변경하지 않음
+- Public API만 사용하여 안정적인 테스트
+
+### 2. Given-When-Then 패턴
+
+```java
+@Test
+@DisplayName("ID로 User를 조회할 수 있다")
+void findUserById() {
+    // given: 테스트 데이터 준비 및 Mock 설정
+    Long userId = 1L;
+    User user = User.of("홍길동", "hong", "hong@example.com", "password", "010-1234-5678");
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    
+    // when: 테스트 대상 메서드 실행
+    Optional<UserResponse> response = userQueryUseCase.findUserById(userId);
+    
+    // then: 결과 검증 및 Mock 호출 검증
+    assertThat(response).isPresent();
+    assertThat(response.get().name()).isEqualTo("홍길동");
+    verify(userRepository, times(1)).findById(userId);
+}
+```
+
+### 3. 명확한 테스트 이름
+
+- `@DisplayName`: 한글 설명 사용 (테스트 의도 명확화)
+- 메서드명: `메서드명_시나리오` 형식 (예: `findUserById_Success`, `findUserById_NotFound`)
+
+### 4. UseCase 반환값 직접 검증
+
+**❌ 나쁜 예:**
+```java
+// Mock 호출 검증에만 집중
+verify(userRepository, times(1)).findById(userId);
+// 반환값 검증 누락
+```
+
+**✅ 좋은 예:**
+```java
+// UseCase의 반환값을 직접 검증
+Optional<UserResponse> response = userQueryUseCase.findUserById(userId);
+assertThat(response).isPresent();
+assertThat(response.get().name()).isEqualTo("홍길동");
+assertThat(response.get().email()).isEqualTo("hong@example.com");
+verify(userRepository, times(1)).findById(userId);
+```
+
+**이유:**
+- UseCase의 실제 결과를 직접 검증
+- DTO 변환 로직의 정확성을 명확하게 확인
+- 테스트 의도가 더 명확함
+
+### 5. Optional 처리 검증
+
+```java
+@Test
+@DisplayName("존재하지 않는 User 조회 시 Optional.empty()를 반환한다")
+void findUserById_NotFound() {
+    // given
+    when(userRepository.findById(999L)).thenReturn(Optional.empty());
+    
+    // when
+    Optional<UserResponse> response = userQueryUseCase.findUserById(999L);
+    
+    // then
+    assertThat(response).isEmpty();
+}
+```
+
+### 6. DTO 변환 로직 검증
+
+UseCase의 DTO 변환 로직을 명확하게 검증한다.
+
+**예시:**
+```java
+@Test
+@DisplayName("ID로 User와 Role을 함께 조회할 수 있다")
+void findUserByIdWithRoles() {
+    // given
+    User user = User.of("홍길동", "hong", "hong@example.com", "password", "010-1234-5678");
+    user.addRole(RoleType.INSTRUCTOR);
+    user.addRole(RoleType.ADMIN);
+    when(userRepository.findByIdWithRoles(userId)).thenReturn(Optional.of(user));
+    
+    // when
+    Optional<UserResponse> response = userQueryUseCase.findUserByIdWithRoles(userId);
+    
+    // then: DTO 변환 및 Role 필터링 검증
+    assertThat(response).isPresent();
+    assertThat(response.get().roles()).hasSize(3);
+    assertThat(response.get().roles()).containsExactlyInAnyOrder(
+        RoleType.STUDENT,
+        RoleType.INSTRUCTOR,
+        RoleType.ADMIN
+    );
+}
+```
+
+### 7. Soft Delete 필터링 검증
+
+```java
+@Test
+@DisplayName("삭제된 Role은 조회 결과에 포함되지 않는다")
+void findUserByIdWithRoles_ExcludesDeletedRoles() {
+    // given
+    User user = User.of("홍길동", "hong", "hong@example.com", "password", "010-1234-5678");
+    user.addRole(RoleType.INSTRUCTOR);
+    user.addRole(RoleType.ADMIN);
+    
+    // Role 하나를 삭제된 상태로 설정
+    user.getRoles().stream()
+        .filter(role -> role.getRoleType() == RoleType.INSTRUCTOR)
+        .findFirst()
+        .ifPresent(role -> {
+            Role deletedRole = Role.builder()
+                .id(role.getId())
+                .userId(role.getUserId())
+                .roleType(role.getRoleType())
+                .createdAt(role.getCreatedAt())
+                .deletedAt(LocalDateTime.now())
+                .build();
+            int index = user.getRoles().indexOf(role);
+            user.getRoles().set(index, deletedRole);
+        });
+    
+    when(userRepository.findByIdWithRoles(userId)).thenReturn(Optional.of(user));
+    
+    // when
+    Optional<UserResponse> response = userQueryUseCase.findUserByIdWithRoles(userId);
+    
+    // then: 삭제된 Role이 제외되었는지 검증
+    assertThat(response).isPresent();
+    assertThat(response.get().roles()).hasSize(2);
+    assertThat(response.get().roles()).doesNotContain(RoleType.INSTRUCTOR);
+}
+```
+
+## Mock vs 통합 테스트
+
+### Mock 테스트 (현재 방식)
+
+**사용 시점:**
+- UseCase 비즈니스 로직 검증
+- DTO 변환 로직 검증
+- 빠른 피드백이 필요한 경우
+- 단위 테스트
+
+**장점:**
+- 빠른 실행
+- 완전한 격리
+- 다양한 시나리오 테스트 용이
+
+**단점:**
+- 실제 DB 동작 검증 불가
+- Mock 설정이 복잡할 수 있음
+
+### 통합 테스트
+
+**사용 시점:**
+- Repository와 DB 연동 검증
+- 실제 데이터 조회 검증
+- JPA 매핑 검증
+- Fetch Join 동작 검증
+
+**장점:**
+- 실제 동작 검증
+- DB 제약조건 검증
+- N+1 문제 검증
+
+**단점:**
+- 느린 실행
+- 테스트 간 간섭 가능성
+
+## 테스트 실행
+
+### 실행 방법
+
+```bash
+# 모든 UseCase 테스트 실행
+./gradlew test --tests "*UseCaseTest"
+
+# 특정 테스트 클래스 실행
+./gradlew test --tests "UserQueryUseCaseTest"
+
+# 특정 테스트 메서드 실행
+./gradlew test --tests "UserQueryUseCaseTest.findUserById"
+```
+
+## 주의사항
+
+### 1. 실제 동작과의 차이
+
+- Mock은 실제 Repository 동작을 완전히 시뮬레이션하지 못할 수 있음
+- Fetch Join 동작은 통합 테스트에서 검증 필요
+- 중요한 통합 테스트는 별도로 작성 권장
+- Mock 테스트와 통합 테스트를 병행하여 사용
+
+### 2. Mock 설정 복잡도
+
+- UseCase가 복잡해질수록 Mock 설정도 복잡해짐
+- Mock 설정이 너무 복잡하면 UseCase 설계를 재검토 필요
+- 단순한 Mock 설정이 가능하도록 UseCase를 설계하는 것이 중요
+
+### 3. DTO 변환 로직 검증 누락
+
+- Mock 호출 검증에만 집중하면 DTO 변환 로직 검증이 누락될 수 있음
+- UseCase의 반환값을 직접 검증하여 DTO 변환 로직을 명확하게 확인
+
+### 4. Soft Delete 필터링 검증
+
+- `UserResponse.from()`에서 삭제된 Role을 필터링하는 로직을 검증해야 함
+- 삭제된 Role이 포함되지 않았는지 명확하게 검증
+
+## 참고
+
+- **Mockito 문법**: `mockito-syntax-overview.md`
+- **통합 테스트**: `UserRepositoryTest` (실제 DB 사용)
+- **UseCase 개요**: `usecase-overview.md`
+- **Repository 개요**: `repository-test-overview.md`

--- a/src/test/java/com/lxp/aplus/user/domain/repository/UserRepositoryTest.java
+++ b/src/test/java/com/lxp/aplus/user/domain/repository/UserRepositoryTest.java
@@ -27,7 +27,7 @@ class UserRepositoryTest {
     @DisplayName("User를 저장하고 조회할 수 있다")
     void saveAndFindById() {
         // given
-        User user = User.of("홍길동", "hong@example.com", "password123");
+        User user = User.of("홍길동", "hong", "hong@example.com", "password123", "010-1234-5678");
 
         // when - save
         User savedUser = userRepository.save(user);
@@ -59,7 +59,7 @@ class UserRepositoryTest {
     @DisplayName("User를 저장하면 Role도 함께 저장된다")
     void save_WithRole() {
         // given
-        User user = User.of("김영희", "kim@example.com", "password123");
+        User user = User.of("김영희", "kim", "kim@example.com", "password123", "010-9876-5432");
         user.addRole(RoleType.INSTRUCTOR); // 추가 역할
 
         // when
@@ -78,7 +78,7 @@ class UserRepositoryTest {
     @DisplayName("User의 닉네임과 이메일을 업데이트할 수 있다")
     void updateUserInfo() {
         // given
-        User user = User.of("이철수", "lee@example.com", "password123");
+        User user = User.of("이철수", "lee",  "lee@example.com", "password123", "010-1111-2222");
         User savedUser = userRepository.save(user);
         LocalDateTime beforeUpdate = savedUser.getUpdatedAt();
 
@@ -99,7 +99,7 @@ class UserRepositoryTest {
     @DisplayName("User의 비밀번호를 변경할 수 있다")
     void changePassword() {
         // given
-        User user = User.of("박민수", "park@example.com", "oldPassword123");
+        User user = User.of("박민수", "park", "park@example.com", "oldPassword123", "010-3333-4444");
         User savedUser = userRepository.save(user);
 
         // when
@@ -117,7 +117,7 @@ class UserRepositoryTest {
     @DisplayName("User를 삭제할 수 있다 (Soft Delete)")
     void delete() {
         // given
-        User user = User.of("최지영", "choi@example.com", "password123");
+        User user = User.of("최지영", "choi", "choi@example.com", "password123", "010-5555-6666");
         User savedUser = userRepository.save(user);
         assertThat(savedUser.getDeletedAt()).isNull();
 
@@ -136,7 +136,7 @@ class UserRepositoryTest {
     @DisplayName("User에 역할을 추가할 수 있다")
     void addRole() {
         // given
-        User user = User.of("강사1", "instructor1@example.com", "password123");
+        User user = User.of("강사1","gang",  "instructor1@example.com", "password123", "010-7777-8888");
         User savedUser = userRepository.save(user);
         assertThat(savedUser.getRoles()).hasSize(1); // 기본 STUDENT 역할
 
@@ -158,7 +158,7 @@ class UserRepositoryTest {
     @DisplayName("User 생성 시 기본적으로 STUDENT 역할이 설정된다")
     void createUser_WithDefaultRole() {
         // when
-        User user = User.of("테스트유저", "test@example.com", "password123");
+        User user = User.of("테스트유저", "test", "test@example.com", "password123", "010-9999-0000");
 
         // then
         assertThat(user.getRoles()).hasSize(1);

--- a/src/test/java/com/lxp/aplus/user/domain/repository/repository-test-overview.md
+++ b/src/test/java/com/lxp/aplus/user/domain/repository/repository-test-overview.md
@@ -1,0 +1,298 @@
+# Repository 테스트 개요
+
+## 목적
+
+Repository 레이어의 실제 DB 연동 및 JPA 동작을 검증하여, Infrastructure 레이어의 정확성을 보장합니다.
+
+## 테스트 전략
+
+### 통합 테스트 (Integration Test)
+
+Repository 테스트는 **실제 인메모리 DB(H2)**를 사용하여 통합 테스트를 수행합니다.
+
+#### Mock을 사용하지 않는 이유
+
+1. **Infrastructure 레이어의 특성**
+   - Repository는 기술 스택(JPA)과의 연동을 담당
+   - 실제 DB 동작을 검증해야 함
+   - Mock으로는 JPA의 실제 동작을 검증할 수 없음
+
+2. **검증해야 할 항목**
+   - JPA 엔티티 매핑 (`@Entity`, `@Table`, `@Column` 등)
+   - 연관관계 매핑 (`@OneToMany`, `@ManyToOne`, `@JoinColumn`)
+   - Cascade 동작 (`CascadeType.ALL`)
+   - Fetch 전략 (`FetchType.LAZY`, `FetchType.EAGER`)
+   - JPA Auditing (`@CreatedDate`, `@LastModifiedDate`)
+   - DB 제약조건 (Unique, Foreign Key 등)
+   - 트랜잭션 동작
+
+3. **UserRepositoryImpl의 역할**
+   - 단순히 `UserJpaRepository`를 위임하는 역할
+   - Mock을 사용하면 위임 로직만 테스트하게 되어 의미가 제한적
+   - 실제 JPA 동작 검증이 더 중요
+
+### 테스트 구조
+
+```java
+@DataJpaTest
+@Import(UserRepositoryImpl.class)
+@DisplayName("UserRepository 테스트")
+class UserRepositoryTest {
+    @Autowired
+    private UserRepository userRepository;
+}
+```
+
+**어노테이션 설명:**
+- `@DataJpaTest`: JPA 관련 컴포넌트만 로드, 인메모리 DB 사용
+- `@Import(UserRepositoryImpl.class)`: Repository 구현체 명시적 등록
+- `@Autowired`: 실제 Repository 구현체 주입
+
+**테스트 환경:**
+- H2 인메모리 데이터베이스 사용
+- 각 테스트 후 자동 롤백 (`@Transactional` 기본 적용)
+- 실제 JPA EntityManager 사용
+
+## 검증 항목
+
+### 1. 기본 CRUD 동작
+
+```java
+@Test
+void saveAndFindById() {
+    // given
+    User user = User.of(...);
+    
+    // when
+    User savedUser = userRepository.save(user);
+    Optional<User> foundUser = userRepository.findById(savedUser.getId());
+    
+    // then
+    assertThat(foundUser).isPresent();
+    assertThat(foundUser.get().getId()).isNotNull(); // ID 자동 생성 검증
+}
+```
+
+**검증 내용:**
+- 엔티티 저장 및 ID 자동 생성
+- 조회 동작
+- JPA 매핑 정확성
+
+### 2. 연관관계 동작
+
+```java
+@Test
+void save_WithRole() {
+    // given
+    User user = User.of(...);
+    user.addRole(RoleType.INSTRUCTOR);
+    
+    // when
+    User savedUser = userRepository.save(user);
+    
+    // then
+    assertThat(savedUser.getRoles()).hasSize(2);
+    // Cascade 동작 검증: User 저장 시 Role도 함께 저장
+}
+```
+
+**검증 내용:**
+- `@OneToMany` 연관관계 매핑
+- `CascadeType.ALL` 동작
+- `@JoinColumn` 매핑
+
+### 3. JPA Auditing
+
+```java
+@Test
+void updateUserInfo() {
+    // given
+    User savedUser = userRepository.save(user);
+    LocalDateTime beforeUpdate = savedUser.getUpdatedAt();
+    
+    // when
+    savedUser.updateUserInfo(...);
+    User updatedUser = userRepository.save(savedUser);
+    
+    // then
+    assertThat(updatedUser.getUpdatedAt()).isAfter(beforeUpdate);
+    // @LastModifiedDate 자동 업데이트 검증
+}
+```
+
+**검증 내용:**
+- `@CreatedDate` 자동 설정
+- `@LastModifiedDate` 자동 업데이트
+- `@EntityListeners(AuditingEntityListener.class)` 동작
+
+### 4. Soft Delete
+
+```java
+@Test
+void delete() {
+    // given
+    User savedUser = userRepository.save(user);
+    
+    // when
+    savedUser.delete(); // deletedAt 설정
+    userRepository.save(savedUser);
+    
+    // then
+    assertThat(foundUser.get().getDeletedAt()).isNotNull();
+    // Soft Delete 동작 검증
+}
+```
+
+**검증 내용:**
+- Soft Delete 필드 업데이트
+- 실제 데이터는 DB에 유지
+
+### 5. 도메인 로직 검증
+
+```java
+@Test
+void createUser_WithDefaultRole() {
+    // when
+    User user = User.of(...);
+    
+    // then
+    assertThat(user.getRoles()).hasSize(1);
+    assertThat(user.getRoles().get(0).getRoleType()).isEqualTo(RoleType.STUDENT);
+    // 정적 팩토리 메서드의 도메인 로직 검증
+}
+```
+
+**검증 내용:**
+- 도메인 메서드 동작
+- 정적 팩토리 메서드 로직
+- 비즈니스 규칙 적용
+
+## Mock vs 통합 테스트 비교
+
+### Repository 테스트 (통합 테스트)
+
+**사용 방식:**
+- 실제 H2 인메모리 DB 사용
+- 실제 JPA EntityManager 사용
+- 실제 트랜잭션 동작
+
+**장점:**
+- 실제 JPA 동작 검증
+- DB 제약조건 검증
+- 연관관계, Cascade, Fetch 전략 검증
+- JPA Auditing 검증
+
+**단점:**
+- UseCase 테스트보다 느림
+- 테스트 간 간섭 가능성 (롤백으로 해결)
+
+### UseCase 테스트 (Mock 테스트)
+
+**사용 방식:**
+- Mock 객체 사용
+- 실제 DB 접근 없음
+
+**장점:**
+- 빠른 실행
+- 완전한 격리
+
+**단점:**
+- 실제 JPA 동작 검증 불가
+- DB 제약조건 검증 불가
+
+## 테스트 실행
+
+### 실행 방법
+
+```bash
+# 모든 Repository 테스트 실행
+./gradlew test --tests "*RepositoryTest"
+
+# 특정 테스트 클래스 실행
+./gradlew test --tests "UserRepositoryTest"
+
+# 특정 테스트 메서드 실행
+./gradlew test --tests "UserRepositoryTest.saveAndFindById"
+```
+
+### 테스트 격리
+
+- `@DataJpaTest`는 각 테스트 메서드마다 트랜잭션 롤백
+- 테스트 간 데이터 간섭 없음
+- 각 테스트는 독립적으로 실행
+
+## 주의사항
+
+### 1. @DataJpaTest의 동작
+
+```java
+@DataJpaTest
+// - JPA 관련 컴포넌트만 로드
+// - 인메모리 DB(H2) 자동 설정
+// - @Transactional 기본 적용 (각 테스트 후 롤백)
+// - @EntityScan, @EnableJpaRepositories 자동 설정
+```
+
+### 2. @Import 필요성
+
+```java
+@Import(UserRepositoryImpl.class)
+// UserRepositoryImpl은 @Repository 어노테이션이 있지만,
+// @DataJpaTest는 특정 패키지만 스캔하므로 명시적 Import 필요
+```
+
+### 3. JPA Auditing 활성화
+
+- `@DataJpaTest`는 `@EnableJpaAuditing`을 자동으로 활성화하지 않음
+- 하지만 `APlusApplication`의 `@EnableJpaAuditing`이 적용됨
+- 별도 설정 불필요
+
+### 4. 트랜잭션 범위
+
+- 각 테스트 메서드는 자동으로 트랜잭션 내에서 실행
+- 테스트 종료 시 자동 롤백
+- `@Transactional(propagation = Propagation.NOT_SUPPORTED)` 사용 시 주의
+
+### 5. 실제 DB와의 차이
+
+- H2는 실제 프로덕션 DB와 다를 수 있음
+- 중요한 DB 제약조건은 별도 통합 테스트 권장
+- 프로덕션 DB와 유사한 환경에서의 테스트도 고려
+
+## Mock을 사용하지 않는 것이 맞는가?
+
+### 결론: **맞습니다**
+
+**이유:**
+
+1. **Repository의 역할**
+   - Infrastructure 레이어의 구현체
+   - 기술 스택(JPA)과의 연동 담당
+   - 실제 동작 검증이 필수
+
+2. **검증 목적**
+   - JPA 매핑, 연관관계, Cascade 등 실제 동작 검증
+   - Mock으로는 이러한 검증이 불가능
+
+3. **테스트 피라미드**
+   - UseCase: 단위 테스트 (Mock 사용) - 빠르고 많음
+   - Repository: 통합 테스트 (실제 DB) - 느리지만 실제 동작 검증
+   - 적절한 균형 유지
+
+4. **UserRepositoryImpl의 단순성**
+   - 단순 위임 로직만 존재
+   - Mock으로 테스트해도 의미가 제한적
+   - 실제 JPA 동작 검증이 더 중요
+
+### Mock을 사용할 수 있는 경우
+
+- Repository에 복잡한 비즈니스 로직이 있는 경우
+- 외부 서비스와의 연동이 있는 경우
+- 하지만 현재 구조에서는 불필요
+
+## 참고
+
+- **UseCase 테스트**: `usecase-test-overview.md` (Mock 사용)
+- **Repository 개요**: `repository-overview.md`
+- **UseCase 개요**: `usecase-overview.md`
+


### PR DESCRIPTION
## ✨ 요약

User 명령(쓰기) UseCase 구현 및 테스트

## 📝 작업 내용

- `UserCommandUseCase` 구현
  - `@Transactional` 적용
  - UserQueryUseCase를 통한 조회 위임
  - DTO 기반 요청/응답 처리
- 주요 기능 구현
  - `createUser`: User 생성 (기본 STUDENT 역할 자동 추가)
  - `updateUserInfo`: 닉네임, 이메일 업데이트
  - `addRole`: Role 추가 (중복 검증 포함)
  - `withdrawUser`: User 탈퇴 처리
  - `activateUser`: User 활성화 (INACTIVE → ACTIVE)
  - `changePassword`: 비밀번호 변경
  - `deleteUser`: Soft Delete 처리 (연관 Role도 함께 삭제)
- Request DTO 추가
  - `CreateUserRequest`, `UpdateUserInfoRequest`, `AddRoleRequest`
  - `WithdrawUserRequest`, `ActivateUserRequest`, `ChangePasswordRequest`, `DeleteUserRequest`
- Mock 기반 단위 테스트 추가
  - 성공 케이스 및 예외 케이스 검증
  - 비즈니스 로직 검증 (Role 중복, 상태 전환 등)

## 💭 주의 사항

- JPA Dirty Checking 활용: `createUser` 외에는 명시적 `save()` 호출 없음
- `findWithRolesById` 사용: Role 접근이 필요한 경우 Fetch Join으로 조회
- 도메인 예외 처리: `BusinessException` 및 `UserErrorCode` 사용
- Soft Delete: `deleteUser`는 `deletedAt` 설정 및 연관 Role도 함께 삭제

## 💡 리뷰 포인트

- CQRS 패턴 적용 (Command/Query 분리)
- UserQueryUseCase 의존성 사용 적절성
- DTO 변환 로직 검증
- 비즈니스 예외 처리 일관성
- JPA Dirty Checking 활용 적절성

## ✅ 테스트

- [x] 로컬 빌드/실행
- [x] 단위 테스트 추가/통과
- [ ] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
