### PR TITLE
[FEAT] 특정 강좌의 전체 강의 수 조회 메서드 & 강의 목록 조회 메서드 추가

### DIFF
--- a/src/main/java/com/lxp/aplus/course/domain/CourseRepository.java
+++ b/src/main/java/com/lxp/aplus/course/domain/CourseRepository.java
@@ -3,6 +3,7 @@ package com.lxp.aplus.course.domain;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CourseRepository {
@@ -10,4 +11,6 @@ public interface CourseRepository {
     Optional<Course> findById(Long id);
     Page<Course> findAllByInstructorId(Long instructorId, Pageable pageable);
     Page<Course> findAllByPublished(Pageable pageable);
+    int countLecturesByCourseId(Long courseId);
+    List<Lecture> findAllLecturesWithResourcesByCourseId(Long courseId);
 }

--- a/src/main/java/com/lxp/aplus/course/infrastructure/persistence/CourseJpaRepository.java
+++ b/src/main/java/com/lxp/aplus/course/infrastructure/persistence/CourseJpaRepository.java
@@ -17,13 +17,13 @@ public interface CourseJpaRepository extends JpaRepository<Course, Long> {
     Page<Course> findAllByCourseStatus(CourseStatus courseStatus, Pageable pageable);
 
     @Query("SELECT COUNT(l) FROM Lecture l " +
-            "JOIN l.section s " +
+            "INNER JOIN l.section s " +
             "WHERE s.course.id = :courseId")
     int countLecturesByCourseId(@Param("courseId") Long courseId);
 
     @Query("SELECT DISTINCT l FROM Lecture l " +
             "LEFT JOIN FETCH l.lectureResources lr " +
-            "JOIN l.section s " +
+            "INNER JOIN l.section s " +
             "WHERE s.course.id = :courseId")
     List<Lecture> findAllLecturesWithResourcesByCourseId(@Param("courseId") Long courseId);
 }

--- a/src/main/java/com/lxp/aplus/course/infrastructure/persistence/CourseJpaRepository.java
+++ b/src/main/java/com/lxp/aplus/course/infrastructure/persistence/CourseJpaRepository.java
@@ -2,11 +2,28 @@ package com.lxp.aplus.course.infrastructure.persistence;
 
 import com.lxp.aplus.course.domain.Course;
 import com.lxp.aplus.course.domain.CourseStatus;
+import com.lxp.aplus.course.domain.Lecture;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CourseJpaRepository extends JpaRepository<Course, Long> {
     Page<Course> findAllByInstructorId(Long instructorId, Pageable pageable);
+
     Page<Course> findAllByCourseStatus(CourseStatus courseStatus, Pageable pageable);
+
+    @Query("SELECT COUNT(l) FROM Lecture l " +
+            "JOIN l.section s " +
+            "WHERE s.course.id = :courseId")
+    int countLecturesByCourseId(@Param("courseId") Long courseId);
+
+    @Query("SELECT DISTINCT l FROM Lecture l " +
+            "LEFT JOIN FETCH l.lectureResources lr " +
+            "JOIN l.section s " +
+            "WHERE s.course.id = :courseId")
+    List<Lecture> findAllLecturesWithResourcesByCourseId(@Param("courseId") Long courseId);
 }

--- a/src/main/java/com/lxp/aplus/course/infrastructure/persistence/CourseRepositoryImpl.java
+++ b/src/main/java/com/lxp/aplus/course/infrastructure/persistence/CourseRepositoryImpl.java
@@ -3,11 +3,13 @@ package com.lxp.aplus.course.infrastructure.persistence;
 import com.lxp.aplus.course.domain.Course;
 import com.lxp.aplus.course.domain.CourseRepository;
 import com.lxp.aplus.course.domain.CourseStatus;
+import com.lxp.aplus.course.domain.Lecture;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -33,5 +35,15 @@ public class CourseRepositoryImpl implements CourseRepository {
     @Override
     public Page<Course> findAllByPublished(Pageable pageable) {
         return jpaRepository.findAllByCourseStatus(CourseStatus.PUBLISHED, pageable);
+    }
+
+    @Override
+    public int countLecturesByCourseId(Long courseId) {
+        return jpaRepository.countLecturesByCourseId(courseId);
+    }
+
+    @Override
+    public List<Lecture> findAllLecturesWithResourcesByCourseId(Long courseId) {
+        return jpaRepository.findAllLecturesWithResourcesByCourseId(courseId);
     }
 }


### PR DESCRIPTION
<!-- PR 제목 : [FEAT] 특정 강좌의 전체 강의 수 조회 메서드 & 강의 목록 조회 메서드 추가 -->

## ✨ 요약

강좌의 진도율 계산 및 학습 이력 상세 조회를 위해, `CourseJpaRepository`에 전체 강의 수 조회(`count`) 및 강의 목록 조회(`list`) 쿼리 메서드를 추가했습니다.

이 과정에서 N+1 문제를 방지하기 위해 `JOIN` 및 `FETCH JOIN`을 적용하여 쿼리 성능을 최적화했습니다.

## 📝 작업 내용

- **Domain & Persistence (Infrastructure)**
    - `CourseRepository` (인터페이스): `countLecturesByCourseId`, `findAllLecturesWithResourcesByCourseId` 메서드 선언
    - `CourseJpaRepository` (JPA): JPQL 쿼리 메서드 구현
        - `countLecturesByCourseId`: 특정 강좌(`courseId`)에 포함된 전체 강의(`Lecture`) 개수 반환 (진도율 계산용)
        - `findAllLecturesWithResourcesByCourseId`: 특정 강좌의 모든 강의(`Lecture`) 목록 조회 + `LectureResource` Fetch Join (학습 이력 상세용)
    - `CourseRepositoryImpl` (구현체): 인터페이스 메서드 구현 및 JPA 호출 연결
- **Query Optimization**
    - `findAllLecturesWithResourcesByCourseId`: `Lecture` -> `LectureResource` 조회 시 N+1 문제를 방지하기 위해 `LEFT JOIN FETCH` 적용
    - `DISTINCT` 키워드를 사용하여 1:N 조인 시 발생할 수 있는 데이터 중복 제거

## 💭 주의 사항

- **N+1 문제 해결**: 기존에 리소스 목록만 반환하던 메서드를 `Lecture` 리스트 반환으로 변경하면서, `lectureResources`를 Fetch Join하여 쿼리 한 번으로 연관 데이터를 모두 가져오도록 설계했습니다.
- **조인 경로**: `Lecture`에서 `Course`까지 직접 연관관계가 없으므로, `Lecture` -> `Section` -> `Course` 순으로 조인하여 `courseId`를 필터링했습니다.

## 💡 리뷰 포인트

- 작성된 JPQL 쿼리의 조인 조건 및 Fetch Join 사용이 적절한지 확인 부탁드립니다.
- 메서드 명명(`count...`, `findAll...`)이 의도를 명확히 전달하는지 검토 바랍니다.

## ✅ 테스트

- [x]  로컬 빌드/실행
- [ ]  단위 테스트 추가/통과
- [ ]  API 수동 테스트 (해당 리포지토리 메서드를 사용하는 API 호출 시 쿼리 로그 확인)