### PR TITLE
[FEAT] 수강 정보 단건 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/lxp/aplus/enrollment/application/result/EnrollmentCreationResult.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/result/EnrollmentCreationResult.java
@@ -6,7 +6,7 @@ public record EnrollmentCreationResult(
         int totalCount,
         List<EnrollmentDetailResult> enrollments
 ) {
-    public static EnrollmentCreationResult from(List<EnrollmentDetailResult> enrollments) {
+    public static EnrollmentCreationResult of(List<EnrollmentDetailResult> enrollments) {
         return new EnrollmentCreationResult(enrollments.size(), enrollments);
     }
 }

--- a/src/main/java/com/lxp/aplus/enrollment/application/result/EnrollmentCreationResult.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/result/EnrollmentCreationResult.java
@@ -6,7 +6,7 @@ public record EnrollmentCreationResult(
         int totalCount,
         List<EnrollmentDetailResult> enrollments
 ) {
-    public static EnrollmentCreationResult of(List<EnrollmentDetailResult> enrollments) {
+    public static EnrollmentCreationResult from(List<EnrollmentDetailResult> enrollments) {
         return new EnrollmentCreationResult(enrollments.size(), enrollments);
     }
 }

--- a/src/main/java/com/lxp/aplus/enrollment/application/result/EnrollmentDetailResult.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/result/EnrollmentDetailResult.java
@@ -10,15 +10,17 @@ public record EnrollmentDetailResult(
         Long studentId,
         Long courseId,
         EnrollmentStatus status,
+        int progressRate,
         LocalDateTime createdAt,
         LocalDateTime expiredAt
 ) {
-    public static EnrollmentDetailResult from(Enrollment enrollment) {
+    public static EnrollmentDetailResult of(Enrollment enrollment, int progressRate) {
         return new EnrollmentDetailResult(
                 enrollment.getId(),
                 enrollment.getStudentId(),
                 enrollment.getCourseId(),
                 enrollment.getStatus(),
+                progressRate,
                 enrollment.getCreatedAt(),
                 enrollment.getExpiredAt()
         );

--- a/src/main/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentCommandUseCase.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentCommandUseCase.java
@@ -51,8 +51,8 @@ public class EnrollmentCommandUseCase{
 
         Enrollment savedEnrollment = enrollmentRepository.save(enrollmentToSave);
 
-        EnrollmentDetailResult createdEnrollment = EnrollmentDetailResult.from(savedEnrollment);
+        EnrollmentDetailResult createdEnrollment = EnrollmentDetailResult.of(savedEnrollment, 0);
 
-        return EnrollmentCreationResult.from(List.of(createdEnrollment));
+        return EnrollmentCreationResult.of(List.of(createdEnrollment));
     }
 }

--- a/src/main/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentCommandUseCase.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentCommandUseCase.java
@@ -53,6 +53,6 @@ public class EnrollmentCommandUseCase{
 
         EnrollmentDetailResult createdEnrollment = EnrollmentDetailResult.of(savedEnrollment, 0);
 
-        return EnrollmentCreationResult.of(List.of(createdEnrollment));
+        return EnrollmentCreationResult.from(List.of(createdEnrollment));
     }
 }

--- a/src/main/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentQueryUseCase.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentQueryUseCase.java
@@ -84,12 +84,6 @@ public class EnrollmentQueryUseCase {
 
 
 
-    public boolean isEnrollmentCompleted(Long enrollmentId) {
-        Enrollment enrollment = enrollmentRepository.findById(enrollmentId)
-                .orElseThrow(() -> new BusinessException(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND_OR_NO_ACCESS));
-        return enrollment.getStatus() == EnrollmentStatus.COMPLETED;
-    }
-
     public long getStudentCountForCourse(Long courseId) {
         return enrollmentRepository.countByCourseId(courseId);
     }

--- a/src/main/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentQueryUseCase.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentQueryUseCase.java
@@ -49,7 +49,10 @@ public class EnrollmentQueryUseCase {
                     }
 
                     Map<Long, Boolean> resourceIdToIsCompletedMap = progressFinder.getCompletionStatusMap(enrollment.getId(), lectureResourceIds);
-                    long completedResources = resourceIdToIsCompletedMap.values().stream().filter(Boolean::booleanValue).count();
+                    long completedResources = resourceIdToIsCompletedMap.values()
+                                                                        .stream()
+                                                                        .filter(Boolean::booleanValue)
+                                                                        .count();
                     int progressRate = (int) ((double) completedResources / lectureResourceIds.size() * 100);
 
                     return EnrollmentListItemResult.of(
@@ -67,15 +70,16 @@ public class EnrollmentQueryUseCase {
         Enrollment enrollment = enrollmentRepository.findById(enrollmentId)
                 .orElseThrow(() -> new BusinessException(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND_OR_NO_ACCESS));
 
-        if (!enrollment.getStudentId().equals(studentId)) {
-            throw new BusinessException(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND_OR_NO_ACCESS);
-        }
+        enrollment.validateOwner(studentId);
 
         List<Long> lectureResourceIds = courseFinder.getLectureResourceIds(enrollment.getCourseId());
         int progressRate = 0;
         if (!lectureResourceIds.isEmpty()) {
             Map<Long, Boolean> resourceIdToIsCompletedMap = progressFinder.getCompletionStatusMap(enrollment.getId(), lectureResourceIds);
-            long completedResources = resourceIdToIsCompletedMap.values().stream().filter(Boolean::booleanValue).count();
+            long completedResources = resourceIdToIsCompletedMap.values()
+                                                                .stream()
+                                                                .filter(Boolean::booleanValue)
+                                                                .count();
             progressRate = (int) ((double) completedResources / lectureResourceIds.size() * 100);
         }
 

--- a/src/main/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentQueryUseCase.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentQueryUseCase.java
@@ -6,6 +6,7 @@ import com.lxp.aplus.common.error.code.EnrollmentErrorCode;
 import com.lxp.aplus.enrollment.application.port.out.CourseFinder;
 import com.lxp.aplus.enrollment.application.port.out.CourseSummary;
 import com.lxp.aplus.enrollment.application.port.out.ProgressFinder;
+import com.lxp.aplus.enrollment.application.result.EnrollmentDetailResult;
 import com.lxp.aplus.enrollment.application.result.EnrollmentListItemResult;
 import com.lxp.aplus.enrollment.domain.Enrollment;
 import com.lxp.aplus.enrollment.domain.EnrollmentRepository;
@@ -60,6 +61,25 @@ public class EnrollmentQueryUseCase {
                 .collect(Collectors.toList());
 
         return new PageImpl<>(content, pageable, enrollmentsPage.getTotalElements());
+    }
+
+    public EnrollmentDetailResult getEnrollmentDetail(Long studentId, Long enrollmentId) {
+        Enrollment enrollment = enrollmentRepository.findById(enrollmentId)
+                .orElseThrow(() -> new BusinessException(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND_OR_NO_ACCESS));
+
+        if (!enrollment.getStudentId().equals(studentId)) {
+            throw new BusinessException(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND_OR_NO_ACCESS);
+        }
+
+        List<Long> lectureResourceIds = courseFinder.getLectureResourceIds(enrollment.getCourseId());
+        int progressRate = 0;
+        if (!lectureResourceIds.isEmpty()) {
+            Map<Long, Boolean> resourceIdToIsCompletedMap = progressFinder.getCompletionStatusMap(enrollment.getId(), lectureResourceIds);
+            long completedResources = resourceIdToIsCompletedMap.values().stream().filter(Boolean::booleanValue).count();
+            progressRate = (int) ((double) completedResources / lectureResourceIds.size() * 100);
+        }
+
+        return EnrollmentDetailResult.of(enrollment, progressRate);
     }
 
 

--- a/src/main/java/com/lxp/aplus/enrollment/domain/Enrollment.java
+++ b/src/main/java/com/lxp/aplus/enrollment/domain/Enrollment.java
@@ -75,4 +75,10 @@ public class Enrollment extends BaseAggregateRoot {
             this.status = EnrollmentStatus.COMPLETED;
         }
     }
+
+    public void validateOwner(Long studentId) {
+        if (!this.studentId.equals(studentId)) {
+            throw new BusinessException(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND_OR_NO_ACCESS);
+        }
+    }
 }

--- a/src/main/java/com/lxp/aplus/enrollment/infrastructure/adapter/CourseFinderAdapter.java
+++ b/src/main/java/com/lxp/aplus/enrollment/infrastructure/adapter/CourseFinderAdapter.java
@@ -4,8 +4,6 @@ import com.lxp.aplus.course.domain.CourseRepository;
 import com.lxp.aplus.enrollment.application.port.out.CourseFinder;
 import com.lxp.aplus.enrollment.application.port.out.CourseSummary;
 
-
-import com.lxp.aplus.course.domain.CourseRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/lxp/aplus/enrollment/presentation/controller/EnrollmentController.java
+++ b/src/main/java/com/lxp/aplus/enrollment/presentation/controller/EnrollmentController.java
@@ -3,15 +3,20 @@ package com.lxp.aplus.enrollment.presentation.controller;
 import com.lxp.aplus.common.result.PageResponse;
 import com.lxp.aplus.common.result.ResultResponse;
 import com.lxp.aplus.common.result.code.EnrollmentResultCode;
+import com.lxp.aplus.common.security.Authenticated;
+import com.lxp.aplus.common.security.UserInfo;
+import com.lxp.aplus.enrollment.application.result.EnrollmentDetailResult;
 import com.lxp.aplus.enrollment.application.result.EnrollmentListItemResult;
 import com.lxp.aplus.enrollment.application.usecase.EnrollmentQueryUseCase;
 import com.lxp.aplus.enrollment.domain.EnrollmentStatus;
+import com.lxp.aplus.enrollment.presentation.response.EnrollmentDetailResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,13 +31,24 @@ public class EnrollmentController {
 
     @GetMapping
     public ResponseEntity<ResultResponse<PageResponse<EnrollmentListItemResult>>> getEnrollmentList(
+            @Authenticated UserInfo currentUser,
             @RequestParam(required = false, defaultValue = "ENROLLED") EnrollmentStatus status,
             @PageableDefault(size = 10, page = 0) Pageable pageable
     ) {
-        Long studentId = 1L;
-        Page<EnrollmentListItemResult> result = enrollmentQueryUseCase.getEnrollmentList(studentId, status, pageable);
+        Page<EnrollmentListItemResult> result = enrollmentQueryUseCase.getEnrollmentList(currentUser.id(), status, pageable);
         return ResponseEntity.ok(
                 ResultResponse.of(EnrollmentResultCode.GET_ENROLLMENTS_SUCCESS, PageResponse.from(result))
+        );
+    }
+
+    @GetMapping("/{enrollmentId}")
+    public ResponseEntity<ResultResponse<EnrollmentDetailResponse>> getEnrollmentDetail(
+            @Authenticated UserInfo currentUser,
+            @PathVariable Long enrollmentId
+    ) {
+        EnrollmentDetailResult result = enrollmentQueryUseCase.getEnrollmentDetail(currentUser.id(), enrollmentId);
+        return ResponseEntity.ok(
+                ResultResponse.of(EnrollmentResultCode.GET_ENROLLMENT_DETAIL_SUCCESS, EnrollmentDetailResponse.from(result))
         );
     }
 }

--- a/src/main/java/com/lxp/aplus/enrollment/presentation/response/EnrollmentDetailResponse.java
+++ b/src/main/java/com/lxp/aplus/enrollment/presentation/response/EnrollmentDetailResponse.java
@@ -1,0 +1,27 @@
+package com.lxp.aplus.enrollment.presentation.response;
+
+import com.lxp.aplus.enrollment.application.result.EnrollmentDetailResult;
+import com.lxp.aplus.enrollment.domain.EnrollmentStatus;
+import java.time.LocalDateTime;
+
+public record EnrollmentDetailResponse(
+        Long enrollmentId,
+        Long studentId,
+        Long courseId,
+        EnrollmentStatus status,
+        int progressRate,
+        LocalDateTime createdAt,
+        LocalDateTime expiredAt
+) {
+    public static EnrollmentDetailResponse from(EnrollmentDetailResult result) {
+        return new EnrollmentDetailResponse(
+                result.enrollmentId(),
+                result.studentId(),
+                result.courseId(),
+                result.status(),
+                result.progressRate(),
+                result.createdAt(),
+                result.expiredAt()
+        );
+    }
+}

--- a/src/test/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentQueryUseCaseTest.java
+++ b/src/test/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentQueryUseCaseTest.java
@@ -5,6 +5,7 @@ import com.lxp.aplus.common.error.code.EnrollmentErrorCode;
 import com.lxp.aplus.enrollment.application.port.out.CourseFinder;
 import com.lxp.aplus.enrollment.application.port.out.CourseSummary;
 import com.lxp.aplus.enrollment.application.port.out.ProgressFinder;
+import com.lxp.aplus.enrollment.application.result.EnrollmentDetailResult;
 import com.lxp.aplus.enrollment.application.result.EnrollmentListItemResult;
 import com.lxp.aplus.enrollment.domain.Enrollment;
 import com.lxp.aplus.enrollment.domain.EnrollmentRepository;
@@ -59,27 +60,23 @@ class EnrollmentQueryUseCaseTest {
         EnrollmentStatus status = EnrollmentStatus.ENROLLED;
         Pageable pageable = PageRequest.of(0, 10);
 
-        // Setup for Enrollment 1
         Enrollment enrollment1 = Enrollment.of(STUDENT_ID, COURSE_ID_1, LocalDateTime.now().plusYears(1));
         ReflectionTestUtils.setField(enrollment1, "id", 5001L);
 
-        List<Long> resourceIds1 = LongStream.rangeClosed(1, 10).boxed().toList(); // 10 lectures
-        Map<Long, Boolean> completionMap1 = Map.of(1L, true, 2L, true, 3L, true, 4L, true); // 4 completed
+        List<Long> resourceIds1 = LongStream.rangeClosed(1, 10).boxed().toList();
+        Map<Long, Boolean> completionMap1 = Map.of(1L, true, 2L, true, 3L, true, 4L, true);
 
-        // Setup for Enrollment 2
         Enrollment enrollment2 = Enrollment.of(STUDENT_ID, COURSE_ID_2, LocalDateTime.now().plusYears(1));
         ReflectionTestUtils.setField(enrollment2, "id", 5002L);
         
-        List<Long> resourceIds2 = LongStream.rangeClosed(11, 30).boxed().toList(); // 20 lectures
-        Map<Long, Boolean> completionMap2 = Map.of(11L, true, 12L, true, 13L, true, 14L, true, 15L, true, 16L, true, 17L, true); // 7 completed
+        List<Long> resourceIds2 = LongStream.rangeClosed(11, 30).boxed().toList();
+        Map<Long, Boolean> completionMap2 = Map.of(11L, true, 12L, true, 13L, true, 14L, true, 15L, true, 16L, true, 17L, true);
 
-        // Mocking repository to return enrollments
         List<Enrollment> enrollments = List.of(enrollment1, enrollment2);
         Page<Enrollment> enrollmentsPage = new PageImpl<>(enrollments, pageable, enrollments.size());
         given(enrollmentRepository.findByStudentIdAndStatus(STUDENT_ID, status, pageable))
                 .willReturn(enrollmentsPage);
 
-        // Mocking course finder for both courses
         given(courseFinder.findCourseById(COURSE_ID_1))
                 .willReturn(Optional.of(new CourseSummary(COURSE_ID_1, COURSE_NAME_1)));
         given(courseFinder.findCourseById(COURSE_ID_2))
@@ -88,7 +85,6 @@ class EnrollmentQueryUseCaseTest {
         given(courseFinder.getLectureResourceIds(COURSE_ID_1)).willReturn(resourceIds1);
         given(courseFinder.getLectureResourceIds(COURSE_ID_2)).willReturn(resourceIds2);
 
-        // Mocking progress finder for both enrollments
         given(progressFinder.getCompletionStatusMap(5001L, resourceIds1)).willReturn(completionMap1);
         given(progressFinder.getCompletionStatusMap(5002L, resourceIds2)).willReturn(completionMap2);
 
@@ -101,11 +97,11 @@ class EnrollmentQueryUseCaseTest {
         
         EnrollmentListItemResult result1 = result.getContent().get(0);
         assertThat(result1.courseId()).isEqualTo(COURSE_ID_1);
-        assertThat(result1.progressRate()).isEqualTo(40); // 4 / 10
+        assertThat(result1.progressRate()).isEqualTo(40);
 
         EnrollmentListItemResult result2 = result.getContent().get(1);
         assertThat(result2.courseId()).isEqualTo(COURSE_ID_2);
-        assertThat(result2.progressRate()).isEqualTo(35); // 7 / 20
+        assertThat(result2.progressRate()).isEqualTo(35);
     }
 
     @Test
@@ -148,7 +144,7 @@ class EnrollmentQueryUseCaseTest {
     void isEnrollmentCompleted_success_false() {
         // given
         Long enrollmentId = 1L;
-        Enrollment enrolledEnrollment = Enrollment.of(1L, 100L, LocalDateTime.now().plusDays(1)); // status is ENROLLED by default
+        Enrollment enrolledEnrollment = Enrollment.of(1L, 100L, LocalDateTime.now().plusDays(1));
         
         given(enrollmentRepository.findById(enrollmentId)).willReturn(Optional.of(enrolledEnrollment));
 
@@ -184,5 +180,70 @@ class EnrollmentQueryUseCaseTest {
 
         // then
         assertThat(result).isEqualTo(5L);
+    }
+
+    @Test
+    @DisplayName("성공 - 수강 상세 정보를 조회해야 한다.")
+    void getEnrollmentDetail_success() {
+        // given
+        Long studentId = STUDENT_ID;
+        Long enrollmentId = 5001L;
+        Long courseId = COURSE_ID_1;
+
+        Enrollment enrollment = Enrollment.of(studentId, courseId, LocalDateTime.now().plusYears(1));
+        ReflectionTestUtils.setField(enrollment, "id", enrollmentId);
+
+        List<Long> lectureResourceIds = LongStream.rangeClosed(1, 10).boxed().toList();
+        Map<Long, Boolean> completionMap = Map.of(1L, true, 2L, true, 3L, true, 4L, true);
+
+        given(enrollmentRepository.findById(enrollmentId)).willReturn(Optional.of(enrollment));
+        given(courseFinder.getLectureResourceIds(courseId)).willReturn(lectureResourceIds);
+        given(progressFinder.getCompletionStatusMap(enrollmentId, lectureResourceIds)).willReturn(completionMap);
+
+        // when
+        EnrollmentDetailResult result = enrollmentQueryUseCase.getEnrollmentDetail(studentId, enrollmentId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.enrollmentId()).isEqualTo(enrollmentId);
+        assertThat(result.studentId()).isEqualTo(studentId);
+        assertThat(result.courseId()).isEqualTo(courseId);
+        assertThat(result.progressRate()).isEqualTo(40); // 4 / 10 * 100
+        assertThat(result.status()).isEqualTo(EnrollmentStatus.ENROLLED); // Default status
+    }
+
+    @Test
+    @DisplayName("실패 - 수강 내역이 없을 때 ENROLLMENT_NOT_FOUND_OR_NO_ACCESS 예외를 던져야 한다.")
+    void getEnrollmentDetail_fail_notFound() {
+        // given
+        Long studentId = STUDENT_ID;
+        Long enrollmentId = 9999L; // Non-existent ID
+
+        given(enrollmentRepository.findById(enrollmentId)).willReturn(Optional.empty());
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> enrollmentQueryUseCase.getEnrollmentDetail(studentId, enrollmentId));
+        assertThat(exception.getErrorCode()).isEqualTo(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND_OR_NO_ACCESS);
+    }
+
+    @Test
+    @DisplayName("실패 - 다른 학생의 수강 내역 조회 시 ENROLLMENT_NOT_FOUND_OR_NO_ACCESS 예외를 던져야 한다.")
+    void getEnrollmentDetail_fail_accessDenied() {
+        // given
+        Long requestingStudentId = STUDENT_ID;
+        Long actualEnrollmentStudentId = STUDENT_ID + 1;
+        Long enrollmentId = 5002L;
+        Long courseId = COURSE_ID_2;
+
+        Enrollment enrollment = Enrollment.of(actualEnrollmentStudentId, courseId, LocalDateTime.now().plusYears(1));
+        ReflectionTestUtils.setField(enrollment, "id", enrollmentId);
+
+        given(enrollmentRepository.findById(enrollmentId)).willReturn(Optional.of(enrollment));
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> enrollmentQueryUseCase.getEnrollmentDetail(requestingStudentId, enrollmentId));
+        assertThat(exception.getErrorCode()).isEqualTo(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND_OR_NO_ACCESS);
     }
 }

--- a/src/test/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentQueryUseCaseTest.java
+++ b/src/test/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentQueryUseCaseTest.java
@@ -123,52 +123,6 @@ class EnrollmentQueryUseCaseTest {
     }
 
     @Test
-    @DisplayName("성공 - 수강 완료 여부를 true로 반환한다")
-    void isEnrollmentCompleted_success_true() {
-        // given
-        Long enrollmentId = 1L;
-        Enrollment completedEnrollment = Enrollment.of(1L, 100L, LocalDateTime.now().plusDays(1));
-        ReflectionTestUtils.setField(completedEnrollment, "status", EnrollmentStatus.COMPLETED);
-        
-        given(enrollmentRepository.findById(enrollmentId)).willReturn(Optional.of(completedEnrollment));
-
-        // when
-        boolean result = enrollmentQueryUseCase.isEnrollmentCompleted(enrollmentId);
-
-        // then
-        assertThat(result).isTrue();
-    }
-
-    @Test
-    @DisplayName("성공 - 수강 완료 여부를 false로 반환한다")
-    void isEnrollmentCompleted_success_false() {
-        // given
-        Long enrollmentId = 1L;
-        Enrollment enrolledEnrollment = Enrollment.of(1L, 100L, LocalDateTime.now().plusDays(1));
-        
-        given(enrollmentRepository.findById(enrollmentId)).willReturn(Optional.of(enrolledEnrollment));
-
-        // when
-        boolean result = enrollmentQueryUseCase.isEnrollmentCompleted(enrollmentId);
-
-        // then
-        assertThat(result).isFalse();
-    }
-
-    @Test
-    @DisplayName("실패 - 수강 내역이 없을 때 예외를 던진다")
-    void isEnrollmentCompleted_fail_notFound() {
-        // given
-        Long enrollmentId = 999L;
-        given(enrollmentRepository.findById(enrollmentId)).willReturn(Optional.empty());
-
-        // when & then
-        BusinessException exception = assertThrows(BusinessException.class,
-                () -> enrollmentQueryUseCase.isEnrollmentCompleted(enrollmentId));
-        assertThat(exception.getErrorCode()).isEqualTo(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND_OR_NO_ACCESS);
-    }
-
-    @Test
     @DisplayName("성공 - 강좌의 수강생 수를 반환한다")
     void getStudentCountForCourse_success() {
         // given


### PR DESCRIPTION
## ✨ 요약
특정 수강 신청 내역(enrollmentId)의 상세 정보를 조회하는 API를 구현했습니다.
단순 조회뿐만 아니라, 요청한 사용자(로그인한 학생)가 해당 수강 내역의 주인인지 검증하는 보안 로직이 포함되어 있습니다.

## 📝 작업 내용
1. Presentation Layer
EnrollmentController
-  GET /api/enrollments/{enrollmentId} 엔드포인트 구현
-  EnrollmentDetailResult를 EnrollmentDetailResponse로 변환하여, API 명세서의 JSON 구조에 맞게 반환

## 💡 리뷰 포인트
예외 처리: 보안 강화를 위해 수강 내역이 없는 경우와 남의 것을 조회하려는 경우를 동일하게 EE004(찾을 수 없거나 접근 권한 없음)로 처리했는데, 이 방식이 적절한지 피드백 부탁드립니다.
- DTO 필드: API 명세서에 있는 필드(progressRate, expiredAt 등)가 빠짐없이 매핑되었는지 확인 부탁드립니다.

## ✅ 테스트
- [x] 로컬 빌드/실행
- [x] 단위 테스트 추가/통과
- [] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
<img width="998" height="333" alt="image" src="https://github.com/user-attachments/assets/c2713176-3ba5-4f69-8dec-defbb06242e2" />

