### PR TITLE
[REFACTOR] User 어노테이션 사용하도록 코드 수정

### DIFF
--- a/src/main/java/com/lxp/aplus/common/security/SecurityConfig.java
+++ b/src/main/java/com/lxp/aplus/common/security/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.lxp.aplus.common.security;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -35,7 +36,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         // 인증 불필요한 엔드포인트
                         .requestMatchers("/api/auth/**").permitAll()
-                        .requestMatchers("/api/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/courses","/api/courses/**").permitAll()
                         // 나머지는 인증 필요
                         .anyRequest().authenticated())
                 

--- a/src/main/java/com/lxp/aplus/course/presentation/controller/CourseController.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/controller/CourseController.java
@@ -4,6 +4,8 @@ import com.lxp.aplus.common.result.PageResponse;
 import com.lxp.aplus.common.result.ResultResponse;
 import com.lxp.aplus.common.result.code.CourseResultCode;
 import com.lxp.aplus.common.result.code.SectionResultCode;
+import com.lxp.aplus.common.security.Authenticated;
+import com.lxp.aplus.common.security.InstructorOnly;
 import com.lxp.aplus.course.application.usecase.CourseCommandUseCase;
 import com.lxp.aplus.course.application.usecase.CourseQueryUseCase;
 import com.lxp.aplus.course.presentation.request.CourseCreateRequest;
@@ -27,7 +29,6 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -36,9 +37,10 @@ public class CourseController {
     private final CourseCommandUseCase courseCommandUseCase;
     private final CourseQueryUseCase courseQueryUseCase;
 
+    @InstructorOnly
     @PostMapping("/api/instructor/courses")
     public ResponseEntity<ResultResponse<CourseUpsertResponse>> createCourse(
-            @RequestParam Long instructorId,
+            @Authenticated Long instructorId,
             @Valid @RequestBody CourseCreateRequest request
     ) {
         CourseUpsertResponse courseUpsertResponse = courseCommandUseCase.createCourse(instructorId, request.toCommand());
@@ -50,10 +52,11 @@ public class CourseController {
                         courseUpsertResponse));
     }
 
+    @InstructorOnly
     @PatchMapping("/api/instructor/courses/{courseId}")
     public ResponseEntity<ResultResponse<CourseUpsertResponse>> updateCourse(
             @PathVariable Long courseId,
-            @RequestParam Long instructorId,
+            @Authenticated Long instructorId,
             @RequestBody CourseUpdateRequest request
     ) {
         CourseUpsertResponse courseUpsertResponse = courseCommandUseCase.updateCourse(courseId, instructorId, request.toCommand());
@@ -65,10 +68,11 @@ public class CourseController {
                         courseUpsertResponse));
     }
 
+    @InstructorOnly
     @GetMapping("/api/instructor/courses/{courseId}")
     public ResponseEntity<ResultResponse<CourseDetailResponse>> getInstructorCourseDetail(
             @PathVariable Long courseId,
-            @RequestParam Long instructorId
+            @Authenticated Long instructorId
     ) {
         CourseDetailResponse courseDetailResponse = courseQueryUseCase.getInstructorCourseDetail(courseId, instructorId);
 
@@ -80,7 +84,7 @@ public class CourseController {
     @GetMapping("/api/courses/{courseId}")
     public ResponseEntity<ResultResponse<CourseDetailResponse>> getPublishedCourseDetail(
             @PathVariable Long courseId,
-            @RequestParam Long userId
+            @Authenticated Long userId
     ) {
         CourseDetailResponse courseDetailResponse = courseQueryUseCase.getPublishedCourseDetail(courseId, userId);
 
@@ -89,9 +93,10 @@ public class CourseController {
                 .body(ResultResponse.of(CourseResultCode.COURSE_READ_SUCCESS, courseDetailResponse));
     }
 
+    @InstructorOnly
     @GetMapping("/api/instructor/courses")
     public ResponseEntity<ResultResponse<PageResponse<CourseResponse>>> getInstructorCourses(
-            @RequestParam Long instructorId,
+            @Authenticated Long instructorId,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         Page<CourseResponse> result = courseQueryUseCase.getInstructorCourses(instructorId, pageable);
@@ -112,10 +117,11 @@ public class CourseController {
                 .body(ResultResponse.of(CourseResultCode.COURSE_LIST_SUCCESS, PageResponse.from(result)));
     }
 
+    @InstructorOnly
     @DeleteMapping("/api/instructor/courses/{courseId}")
     public ResponseEntity<ResultResponse<Void>> deleteCourse(
             @PathVariable Long courseId,
-            @RequestParam Long instructorId
+            @Authenticated Long instructorId
     ) {
         courseCommandUseCase.deleteCourse(courseId, instructorId);
 
@@ -124,10 +130,11 @@ public class CourseController {
                 .body(ResultResponse.from(CourseResultCode.COURSE_DELETE_SUCCESS));
     }
 
+    @InstructorOnly
     @PostMapping("/api/instructor/courses/{courseId}/sections")
     public ResponseEntity<ResultResponse<SectionUpsertResponse>> createSection(
             @PathVariable Long courseId,
-            @RequestParam Long instructorId,
+            @Authenticated Long instructorId,
             @Valid @RequestBody SectionCreateRequest request
     ) {
         SectionUpsertResponse response = courseCommandUseCase.createSection(courseId, instructorId, request.toCommand());
@@ -137,11 +144,12 @@ public class CourseController {
                 .body(ResultResponse.of(SectionResultCode.SECTION_REGISTER_SUCCESS, response));
     }
 
+    @InstructorOnly
     @PatchMapping("/api/instructor/courses/{courseId}/sections/{sectionId}")
     public ResponseEntity<ResultResponse<SectionUpsertResponse>> updateSection(
             @PathVariable Long courseId,
             @PathVariable Long sectionId,
-            @RequestParam Long instructorId,
+            @Authenticated Long instructorId,
             @RequestBody SectionUpdateRequest request
     ) {
         SectionUpsertResponse response = courseCommandUseCase.updateSection(courseId, instructorId, sectionId, request.toCommand());
@@ -151,11 +159,12 @@ public class CourseController {
                 .body(ResultResponse.of(SectionResultCode.SECTION_UPDATE_SUCCESS, response));
     }
 
+    @InstructorOnly
     @DeleteMapping("/api/instructor/courses/{courseId}/sections/{sectionId}")
     public ResponseEntity<ResultResponse<Void>> deleteSection(
             @PathVariable Long courseId,
             @PathVariable Long sectionId,
-            @RequestParam Long instructorId
+            @Authenticated Long instructorId
     ) {
         courseCommandUseCase.deleteSection(courseId, instructorId, sectionId);
 


### PR DESCRIPTION
[REFACTOR] CourseController 보안 어노테이션(@Authenticated, @InstructorOnly) 적용

## ✨ 요약
`CourseController`에서 사용자 ID를 파라미터로 직접 받던 방식을 개선하여, 커스텀 보안 어노테이션(`@Authenticated`, `@InstructorOnly`)을 사용하도록 리팩토링했습니다.

## 📝 작업 내용
- **`@RequestParam` 제거**: `instructorId`, `userId` 등 클라이언트로부터 직접 ID를 받던 파라미터를 제거했습니다.
- **`@Authenticated` 적용**: `SecurityContext`에 저장된 인증 정보를 바탕으로 사용자 ID를 컨트롤러 메서드에 자동 주입하도록 변경했습니다.
- **`@InstructorOnly` 적용**: 강좌 생성, 수정, 삭제 등 강사 권한이 필요한 API에 어노테이션을 추가하여 AOP를 통한 권한 검증 로직을 적용했습니다.
- **API 시그니처 변경**: 불필요한 파라미터가 제거됨에 따라 API 호출 시 ID를 전달할 필요가 없어졌습니다.

## 💭 주의 사항
- 클라이언트(프론트엔드)에서 API 호출 시 더 이상 `instructorId`나 `userId`를 쿼리 파라미터로 보낼 필요가 없으므로, 프론트엔드 코드 수정이 필요할 수 있습니다.
- `SecurityConfig` 및 `JwtAuthenticationFilter`가 정상적으로 동작하여 `SecurityContext`에 인증 정보가 설정되어 있어야 합니다.

## 💡 리뷰 포인트
- 각 API 메서드에 적절한 권한(`@InstructorOnly` 필요 여부)이 설정되었는지 확인 부탁드립니다.

## ✅ 테스트
- [x] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [ ] API 수동 테스트 (Postman/Swagger 등을 통해 토큰 헤더 포함 요청 테스트)

## 📸 참고(스크린샷 / API 예시)