### PR TITLE
[FEAT] 강좌별 단건 학습 이력 조회 api 구현

### DIFF
--- a/src/main/java/com/lxp/aplus/enrollment/application/port/out/CourseFinder.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/port/out/CourseFinder.java
@@ -7,4 +7,5 @@ public interface CourseFinder {
     Optional<CourseSummary> findCourseById(Long courseId);
     int countLectures(Long courseId);
     List<Long> getLectureResourceIds(Long courseId);
+    List<LectureResourceSummary> findAllLectureResourcesByCourseId(Long courseId);
 }

--- a/src/main/java/com/lxp/aplus/enrollment/application/port/out/LectureResourceSummary.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/port/out/LectureResourceSummary.java
@@ -1,0 +1,8 @@
+package com.lxp.aplus.enrollment.application.port.out;
+
+public record LectureResourceSummary(
+        Long resourceId,
+        String title,
+        Integer totalDurationSeconds
+) {
+}

--- a/src/main/java/com/lxp/aplus/enrollment/infrastructure/adapter/CourseFinderAdapter.java
+++ b/src/main/java/com/lxp/aplus/enrollment/infrastructure/adapter/CourseFinderAdapter.java
@@ -3,11 +3,10 @@ package com.lxp.aplus.enrollment.infrastructure.adapter;
 import com.lxp.aplus.course.domain.CourseRepository;
 import com.lxp.aplus.enrollment.application.port.out.CourseFinder;
 import com.lxp.aplus.enrollment.application.port.out.CourseSummary;
-
+import com.lxp.aplus.enrollment.application.port.out.LectureResourceSummary;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -35,6 +34,19 @@ public class CourseFinderAdapter implements CourseFinder {
         return courseRepository.findAllLecturesWithResourcesByCourseId(courseId).stream()
                 .flatMap(lecture -> lecture.getLectureResources().stream())
                 .map(lectureResource -> lectureResource.getId())
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<LectureResourceSummary> findAllLectureResourcesByCourseId(Long courseId) {
+        return courseRepository.findAllLecturesWithResourcesByCourseId(courseId).stream()
+                .flatMap(lecture -> lecture.getLectureResources().stream())
+                .map(resource -> new LectureResourceSummary(
+                        resource.getId(),
+                        resource.getLecture().getTitle(),
+                        resource.getLecture().getTotalDurationSeconds()
+                ))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/lxp/aplus/enrollment/presentation/controller/EnrollmentController.java
+++ b/src/main/java/com/lxp/aplus/enrollment/presentation/controller/EnrollmentController.java
@@ -28,7 +28,6 @@ public class EnrollmentController {
 
     private final EnrollmentQueryUseCase enrollmentQueryUseCase;
 
-
     @GetMapping
     public ResponseEntity<ResultResponse<PageResponse<EnrollmentListItemResult>>> getEnrollmentList(
             @Authenticated UserInfo currentUser,

--- a/src/main/java/com/lxp/aplus/progress/application/result/EnrollmentProgressResult.java
+++ b/src/main/java/com/lxp/aplus/progress/application/result/EnrollmentProgressResult.java
@@ -2,7 +2,6 @@ package com.lxp.aplus.progress.application.result;
 
 import java.time.LocalDateTime;
 import java.util.List;
-
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/com/lxp/aplus/progress/application/result/LearningHistoryResult.java
+++ b/src/main/java/com/lxp/aplus/progress/application/result/LearningHistoryResult.java
@@ -1,0 +1,14 @@
+package com.lxp.aplus.progress.application.result;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record LearningHistoryResult(
+    Long enrollmentId,
+    int overallProgressRate,
+    Long lastWatchedVideoId,
+    Integer lastWatchedDurationOfLastVideo,
+    LocalDateTime lastWatchedAt,
+    List<LectureProgressResult> lectureProgresses
+) {
+}

--- a/src/main/java/com/lxp/aplus/progress/application/result/LectureProgressResult.java
+++ b/src/main/java/com/lxp/aplus/progress/application/result/LectureProgressResult.java
@@ -1,7 +1,6 @@
 package com.lxp.aplus.progress.application.result;
 
 import com.lxp.aplus.enrollment.application.port.out.LectureResourceSummary;
-import com.lxp.aplus.progress.domain.Progress;
 import java.time.LocalDateTime;
 
 public record LectureProgressResult(
@@ -13,32 +12,27 @@ public record LectureProgressResult(
         boolean isCompleted,
         LocalDateTime lastWatchedAt
 ) {
-    public static LectureProgressResult from(LectureResourceSummary resourceSummary, Progress progress) {
-        int watched = progress != null ? progress.getWatchedDuration() : 0;
-        boolean completed = progress != null && progress.isCompleted();
-        LocalDateTime lastWatched = progress != null ? progress.getLastWatchedAt() : null;
-
+    public static LectureProgressResult of(
+            LectureResourceSummary resourceSummary,
+            int watchedDuration,
+            boolean isCompleted,
+            LocalDateTime lastWatchedAt,
+            int currentProgressRate
+    ) {
         int totalDuration = resourceSummary.totalDurationSeconds() != null ? resourceSummary.totalDurationSeconds() : 0;
-
-        int progressRate = 0;
-        if (totalDuration > 0) {
-            progressRate = (int) ((double) watched / totalDuration * 100);
-        } else if (completed) {
-            progressRate = 100;
-        }
 
         return new LectureProgressResult(
                 resourceSummary.resourceId(),
                 resourceSummary.title(),
-                progressRate,
-                watched,
+                currentProgressRate,
+                watchedDuration,
                 totalDuration,
-                completed,
-                lastWatched
+                isCompleted,
+                lastWatchedAt
         );
     }
 
     public static LectureProgressResult from(LectureResourceSummary resourceSummary) {
-        return from(resourceSummary, null);
+        return of(resourceSummary, 0, false, null, 0); 
     }
 }

--- a/src/main/java/com/lxp/aplus/progress/application/result/LectureProgressResult.java
+++ b/src/main/java/com/lxp/aplus/progress/application/result/LectureProgressResult.java
@@ -1,5 +1,7 @@
 package com.lxp.aplus.progress.application.result;
 
+import com.lxp.aplus.enrollment.application.port.out.LectureResourceSummary;
+import com.lxp.aplus.progress.domain.Progress;
 import java.time.LocalDateTime;
 
 public record LectureProgressResult(
@@ -7,11 +9,36 @@ public record LectureProgressResult(
         String title,
         int currentProgressRate,
         int watchedDuration,
-        int totalDuration,
+        int totalDurationSeconds,
         boolean isCompleted,
         LocalDateTime lastWatchedAt
 ) {
-    public static LectureProgressResult of(Long resourceId, String title, int currentProgressRate, int watchedDuration, int totalDuration, boolean isCompleted, LocalDateTime lastWatchedAt) {
-        return new LectureProgressResult(resourceId, title, currentProgressRate, watchedDuration, totalDuration, isCompleted, lastWatchedAt);
+    public static LectureProgressResult from(LectureResourceSummary resourceSummary, Progress progress) {
+        int watched = progress != null ? progress.getWatchedDuration() : 0;
+        boolean completed = progress != null && progress.isCompleted();
+        LocalDateTime lastWatched = progress != null ? progress.getLastWatchedAt() : null;
+
+        int totalDuration = resourceSummary.totalDurationSeconds() != null ? resourceSummary.totalDurationSeconds() : 0;
+
+        int progressRate = 0;
+        if (totalDuration > 0) {
+            progressRate = (int) ((double) watched / totalDuration * 100);
+        } else if (completed) {
+            progressRate = 100;
+        }
+
+        return new LectureProgressResult(
+                resourceSummary.resourceId(),
+                resourceSummary.title(),
+                progressRate,
+                watched,
+                totalDuration,
+                completed,
+                lastWatched
+        );
+    }
+
+    public static LectureProgressResult from(LectureResourceSummary resourceSummary) {
+        return from(resourceSummary, null);
     }
 }

--- a/src/main/java/com/lxp/aplus/progress/application/usecase/ProgressCommandUseCase.java
+++ b/src/main/java/com/lxp/aplus/progress/application/usecase/ProgressCommandUseCase.java
@@ -36,7 +36,8 @@ public class ProgressCommandUseCase {
             throw new BusinessException(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND_OR_NO_ACCESS);
         }
 
-        Lecture parentLecture = courseRepository.findAllLecturesWithResourcesByCourseId(enrollment.getCourseId()).stream()
+        Lecture parentLecture = courseRepository.findAllLecturesWithResourcesByCourseId(enrollment
+                        .getCourseId()).stream()
                 .filter(lecture -> lecture.getLectureResources().stream()
                         .anyMatch(resource -> resource.getId().equals(request.resourceId())))
                 .findFirst()
@@ -47,7 +48,8 @@ public class ProgressCommandUseCase {
                 .findFirst()
                 .get();
 
-        Optional<Progress> existingProgress = progressRepository.findByEnrollmentAndLectureResource(enrollment, lectureResource);
+        Optional<Progress> existingProgress = progressRepository
+                .findByEnrollmentAndLectureResource(enrollment, lectureResource);
         Progress progress;
 
         if (existingProgress.isPresent()) {

--- a/src/main/java/com/lxp/aplus/progress/application/usecase/ProgressQueryUseCase.java
+++ b/src/main/java/com/lxp/aplus/progress/application/usecase/ProgressQueryUseCase.java
@@ -1,13 +1,24 @@
 package com.lxp.aplus.progress.application.usecase;
 
+import com.lxp.aplus.common.error.BusinessException;
+import com.lxp.aplus.common.error.code.EnrollmentErrorCode;
+import com.lxp.aplus.common.error.code.ProgressErrorCode;
+import com.lxp.aplus.enrollment.application.port.out.CourseFinder;
+import com.lxp.aplus.enrollment.application.port.out.LectureResourceSummary;
+import com.lxp.aplus.enrollment.domain.Enrollment;
+import com.lxp.aplus.enrollment.domain.EnrollmentRepository;
+import com.lxp.aplus.progress.application.result.LearningHistoryResult;
+import com.lxp.aplus.progress.application.result.LectureProgressResult;
 import com.lxp.aplus.progress.domain.Progress;
 import com.lxp.aplus.progress.domain.ProgressRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -15,15 +26,64 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class ProgressQueryUseCase {
 
+    private final EnrollmentRepository enrollmentRepository;
+    private final CourseFinder courseFinder;
     private final ProgressRepository progressRepository;
+    private static final int PERCENTAGE_MULTIPLIER = 100;
 
-    public Map<Long, Boolean> checkLectureCompletionStatus(Long enrollmentId, List<Long> lectureResourceIds) {
-        List<Progress> progresses = progressRepository.findByEnrollmentIdAndLectureResourceIds(enrollmentId, lectureResourceIds);
+    public LearningHistoryResult getLearningHistory(Long studentId, Long enrollmentId) {
+        Enrollment enrollment = enrollmentRepository.findById(enrollmentId)
+                .orElseThrow(() -> new BusinessException(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND_OR_NO_ACCESS));
+        enrollment.validateOwner(studentId);
 
-        return progresses.stream()
-                .collect(Collectors.toMap(
-                        progress -> progress.getLectureResource().getId(),
-                        Progress::isCompleted
-                ));
+        if (enrollment.isExpired()) {
+            throw new BusinessException(EnrollmentErrorCode.ENROLLMENT_EXPIRED_HISTORY_ACCESS_DENIED);
+        }
+
+        List<LectureResourceSummary> allLectureResources = courseFinder.findAllLectureResourcesByCourseId(enrollment.getCourseId());
+        
+        if (allLectureResources.isEmpty()) {
+            throw new BusinessException(ProgressErrorCode.LEARNING_HISTORY_NOT_FOUND);
+        }
+
+        List<Long> allResourceIds = allLectureResources.stream()
+                .map(LectureResourceSummary::resourceId)
+                .collect(Collectors.toList());
+        
+        List<Progress> progresses = progressRepository.findByEnrollmentIdAndLectureResourceIds(enrollmentId, allResourceIds);
+        
+        if (progresses.isEmpty()) {
+            throw new BusinessException(ProgressErrorCode.LEARNING_HISTORY_NOT_FOUND);
+        }
+
+        Map<Long, Progress> progressMap = progresses.stream()
+                .collect(Collectors.toMap(p -> p.getLectureResource().getId(), p -> p)); 
+
+        List<LectureProgressResult> lectureProgresses = allLectureResources.stream()
+                .map(resourceSummary -> {
+                    Progress progress = progressMap.get(resourceSummary.resourceId());
+                    return LectureProgressResult.from(resourceSummary, progress); 
+                })
+                .collect(Collectors.toList());
+
+        long completedCount = lectureProgresses.stream().filter(LectureProgressResult::isCompleted).count();
+        int overallProgressRate = (int) ((double) completedCount / allResourceIds.size() * PERCENTAGE_MULTIPLIER);
+
+        Optional<Progress> lastWatchedProgress = progresses.stream()
+                .filter(p -> p.getLastWatchedAt() != null)
+                .max(Comparator.comparing(Progress::getLastWatchedAt));
+        
+        Long lastWatchedVideoId = lastWatchedProgress.map(p -> p.getLectureResource().getId()).orElse(null);
+        Integer lastWatchedDuration = lastWatchedProgress.map(Progress::getWatchedDuration).orElse(null);
+        java.time.LocalDateTime lastWatchedAt = lastWatchedProgress.map(Progress::getLastWatchedAt).orElse(null);
+
+        return new LearningHistoryResult(
+                enrollmentId,
+                overallProgressRate,
+                lastWatchedVideoId,
+                lastWatchedDuration,
+                lastWatchedAt,
+                lectureProgresses
+        );
     }
 }

--- a/src/main/java/com/lxp/aplus/progress/application/usecase/ProgressQueryUseCase.java
+++ b/src/main/java/com/lxp/aplus/progress/application/usecase/ProgressQueryUseCase.java
@@ -2,7 +2,6 @@ package com.lxp.aplus.progress.application.usecase;
 
 import com.lxp.aplus.common.error.BusinessException;
 import com.lxp.aplus.common.error.code.EnrollmentErrorCode;
-import com.lxp.aplus.common.error.code.ProgressErrorCode;
 import com.lxp.aplus.enrollment.application.port.out.CourseFinder;
 import com.lxp.aplus.enrollment.application.port.out.LectureResourceSummary;
 import com.lxp.aplus.enrollment.domain.Enrollment;
@@ -15,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -40,30 +40,33 @@ public class ProgressQueryUseCase {
             throw new BusinessException(EnrollmentErrorCode.ENROLLMENT_EXPIRED_HISTORY_ACCESS_DENIED);
         }
 
-        List<LectureResourceSummary> allLectureResources = courseFinder.findAllLectureResourcesByCourseId(enrollment.getCourseId());
+        List<LectureResourceSummary> allLectureResources = courseFinder.
+                findAllLectureResourcesByCourseId(enrollment.getCourseId());
         
+        // 강의 자료가 없을 경우, 빈 목록과 0% 진도로 처리
         if (allLectureResources.isEmpty()) {
-            throw new BusinessException(ProgressErrorCode.LEARNING_HISTORY_NOT_FOUND);
+            return new LearningHistoryResult(
+                    enrollmentId,
+                    0, // overallProgressRate
+                    null, // lastWatchedVideoId
+                    null, // lastWatchedDurationOfLastVideo
+                    null, // lastWatchedAt
+                    Collections.emptyList() // lectureProgresses
+            );
         }
 
         List<Long> allResourceIds = allLectureResources.stream()
                 .map(LectureResourceSummary::resourceId)
                 .collect(Collectors.toList());
         
-        List<Progress> progresses = progressRepository.findByEnrollmentIdAndLectureResourceIds(enrollmentId, allResourceIds);
-        
-        if (progresses.isEmpty()) {
-            throw new BusinessException(ProgressErrorCode.LEARNING_HISTORY_NOT_FOUND);
-        }
+        List<Progress> progresses = progressRepository
+                .findByEnrollmentIdAndLectureResourceIds(enrollmentId, allResourceIds);
 
         Map<Long, Progress> progressMap = progresses.stream()
                 .collect(Collectors.toMap(p -> p.getLectureResource().getId(), p -> p)); 
 
         List<LectureProgressResult> lectureProgresses = allLectureResources.stream()
-                .map(resourceSummary -> {
-                    Progress progress = progressMap.get(resourceSummary.resourceId());
-                    return LectureProgressResult.from(resourceSummary, progress); 
-                })
+                .map(resourceSummary -> createLectureProgressResult(resourceSummary, progressMap))
                 .collect(Collectors.toList());
 
         long completedCount = lectureProgresses.stream().filter(LectureProgressResult::isCompleted).count();
@@ -85,5 +88,19 @@ public class ProgressQueryUseCase {
                 lastWatchedAt,
                 lectureProgresses
         );
+    }
+
+    private LectureProgressResult createLectureProgressResult(LectureResourceSummary resourceSummary, Map<Long, Progress> progressMap) {
+        Progress progress = progressMap.get(resourceSummary.resourceId());
+        int watchedDuration = progress != null ? progress.getWatchedDuration() : 0;
+        boolean isCompleted = progress != null ? progress.isCompleted() : false;
+        java.time.LocalDateTime lastWatchedAt = progress != null ? progress.getLastWatchedAt() : null;
+
+        int progressRate = 0;
+        if (progress != null) {
+            progressRate = progress.calculateProgressRate();
+        }
+
+        return LectureProgressResult.of(resourceSummary, watchedDuration, isCompleted, lastWatchedAt, progressRate);
     }
 }

--- a/src/main/java/com/lxp/aplus/progress/application/usecase/ProgressQueryUseCase.java
+++ b/src/main/java/com/lxp/aplus/progress/application/usecase/ProgressQueryUseCase.java
@@ -13,7 +13,6 @@ import com.lxp.aplus.progress.domain.ProgressRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -42,14 +41,13 @@ public class ProgressQueryUseCase {
 
         List<LectureResourceSummary> allLectureResources = courseFinder.
                 findAllLectureResourcesByCourseId(enrollment.getCourseId());
-        
-        // 강의 자료가 없을 경우, 빈 목록과 0% 진도로 처리
+
         if (allLectureResources.isEmpty()) {
             return new LearningHistoryResult(
                     enrollmentId,
                     0, // overallProgressRate
-                    null, // lastWatchedVideoId
-                    null, // lastWatchedDurationOfLastVideo
+                    0L, // lastWatchedVideoId (null 대신 0L)
+                    0, // lastWatchedDurationOfLastVideo (null 대신 0)
                     null, // lastWatchedAt
                     Collections.emptyList() // lectureProgresses
             );
@@ -76,8 +74,8 @@ public class ProgressQueryUseCase {
                 .filter(p -> p.getLastWatchedAt() != null)
                 .max(Comparator.comparing(Progress::getLastWatchedAt));
         
-        Long lastWatchedVideoId = lastWatchedProgress.map(p -> p.getLectureResource().getId()).orElse(null);
-        Integer lastWatchedDuration = lastWatchedProgress.map(Progress::getWatchedDuration).orElse(null);
+        Long lastWatchedVideoId = lastWatchedProgress.map(p -> p.getLectureResource().getId()).orElse(0L);
+        Integer lastWatchedDuration = lastWatchedProgress.map(Progress::getWatchedDuration).orElse(0);
         java.time.LocalDateTime lastWatchedAt = lastWatchedProgress.map(Progress::getLastWatchedAt).orElse(null);
 
         return new LearningHistoryResult(

--- a/src/main/java/com/lxp/aplus/progress/domain/Progress.java
+++ b/src/main/java/com/lxp/aplus/progress/domain/Progress.java
@@ -20,6 +20,9 @@ import java.util.Objects;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Progress extends BaseTimeEntity {
 
+    private static final int MAX_PERCENTAGE_VALUE = 100; // 최대 백분율 값
+    private static final int PERCENTAGE_CONVERSION_FACTOR = 100; // 백분율 변환 곱셈 인자
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "progress_id")
@@ -80,8 +83,8 @@ public class Progress extends BaseTimeEntity {
     public int calculateProgressRate() {
         int totalDuration = this.lectureResource.getLecture().getTotalDurationSeconds();
         if (totalDuration == 0) {
-            return 0;
+            return this.isCompleted ? MAX_PERCENTAGE_VALUE : 0;
         }
-        return (int) (((double) this.watchedDuration / totalDuration) * 100);
+        return (int) (((double) this.watchedDuration / totalDuration) * PERCENTAGE_CONVERSION_FACTOR);
     }
 }

--- a/src/main/java/com/lxp/aplus/progress/domain/ProgressRepository.java
+++ b/src/main/java/com/lxp/aplus/progress/domain/ProgressRepository.java
@@ -2,8 +2,8 @@ package com.lxp.aplus.progress.domain;
 
 import com.lxp.aplus.course.domain.LectureResource;
 import com.lxp.aplus.enrollment.domain.Enrollment;
-
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface ProgressRepository {
@@ -12,4 +12,5 @@ public interface ProgressRepository {
     List<Progress> findByEnrollmentId(Long enrollmentId);
     long countByEnrollmentIdAndIsCompleted(Long enrollmentId, boolean isCompleted);
     List<Progress> findByEnrollmentIdAndLectureResourceIds(Long enrollmentId, List<Long> lectureResourceIds);
+    Map<Long, Boolean> getCompletionStatusMap(Long enrollmentId, List<Long> lectureResourceIds);
 }

--- a/src/main/java/com/lxp/aplus/progress/infrastructure/persistence/ProgressJpaRepository.java
+++ b/src/main/java/com/lxp/aplus/progress/infrastructure/persistence/ProgressJpaRepository.java
@@ -4,6 +4,8 @@ import com.lxp.aplus.course.domain.LectureResource;
 import com.lxp.aplus.enrollment.domain.Enrollment;
 import com.lxp.aplus.progress.domain.Progress;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Optional;
 
@@ -11,5 +13,7 @@ public interface ProgressJpaRepository extends JpaRepository<Progress, Long> {
     Optional<Progress> findByEnrollmentAndLectureResource(Enrollment enrollment, LectureResource lectureResource);
     List<Progress> findByEnrollmentId(Long enrollmentId);
     long countByEnrollmentIdAndIsCompleted(Long enrollmentId, boolean isCompleted);
-    List<Progress> findByEnrollment_IdAndLectureResource_IdIn(Long enrollmentId, List<Long> lectureResourceIds);
+
+    @Query("SELECT p FROM Progress p JOIN FETCH p.lectureResource lr WHERE p.enrollment.id = :enrollmentId AND lr.id IN :lectureResourceIds")
+    List<Progress> findByEnrollment_IdAndLectureResource_IdIn(@Param("enrollmentId") Long enrollmentId, @Param("lectureResourceIds") List<Long> lectureResourceIds);
 }

--- a/src/main/java/com/lxp/aplus/progress/infrastructure/persistence/ProgressJpaRepository.java
+++ b/src/main/java/com/lxp/aplus/progress/infrastructure/persistence/ProgressJpaRepository.java
@@ -4,8 +4,7 @@ import com.lxp.aplus.course.domain.LectureResource;
 import com.lxp.aplus.enrollment.domain.Enrollment;
 import com.lxp.aplus.progress.domain.Progress;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.EntityGraph;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,6 +13,6 @@ public interface ProgressJpaRepository extends JpaRepository<Progress, Long> {
     List<Progress> findByEnrollmentId(Long enrollmentId);
     long countByEnrollmentIdAndIsCompleted(Long enrollmentId, boolean isCompleted);
 
-    @Query("SELECT p FROM Progress p JOIN FETCH p.lectureResource lr WHERE p.enrollment.id = :enrollmentId AND lr.id IN :lectureResourceIds")
-    List<Progress> findByEnrollment_IdAndLectureResource_IdIn(@Param("enrollmentId") Long enrollmentId, @Param("lectureResourceIds") List<Long> lectureResourceIds);
+    @EntityGraph(attributePaths = "lectureResource")
+    List<Progress> findByEnrollment_IdAndLectureResource_IdIn(Long enrollmentId, List<Long> lectureResourceIds);
 }

--- a/src/main/java/com/lxp/aplus/progress/infrastructure/persistence/ProgressRepositoryImpl.java
+++ b/src/main/java/com/lxp/aplus/progress/infrastructure/persistence/ProgressRepositoryImpl.java
@@ -6,9 +6,10 @@ import com.lxp.aplus.progress.domain.Progress;
 import com.lxp.aplus.progress.domain.ProgressRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -39,5 +40,15 @@ public class ProgressRepositoryImpl implements ProgressRepository {
     @Override
     public List<Progress> findByEnrollmentIdAndLectureResourceIds(Long enrollmentId, List<Long> lectureResourceIds) {
         return progressJpaRepository.findByEnrollment_IdAndLectureResource_IdIn(enrollmentId, lectureResourceIds);
+    }
+
+    @Override
+    public Map<Long, Boolean> getCompletionStatusMap(Long enrollmentId, List<Long> lectureResourceIds) {
+        List<Progress> progresses = findByEnrollmentIdAndLectureResourceIds(enrollmentId, lectureResourceIds);
+        return progresses.stream()
+                .collect(Collectors.toMap(
+                        progress -> progress.getLectureResource().getId(),
+                        Progress::isCompleted
+                ));
     }
 }

--- a/src/main/java/com/lxp/aplus/progress/presentation/controller/ProgressController.java
+++ b/src/main/java/com/lxp/aplus/progress/presentation/controller/ProgressController.java
@@ -2,15 +2,18 @@ package com.lxp.aplus.progress.presentation.controller;
 
 import com.lxp.aplus.common.result.ResultResponse;
 import com.lxp.aplus.common.result.code.ProgressResultCode;
-
 import com.lxp.aplus.common.security.Authenticated;
 import com.lxp.aplus.common.security.UserInfo;
+import com.lxp.aplus.progress.application.result.LearningHistoryResult;
 import com.lxp.aplus.progress.application.usecase.ProgressCommandUseCase;
+import com.lxp.aplus.progress.application.usecase.ProgressQueryUseCase;
 import com.lxp.aplus.progress.presentation.request.ProgressUpdateRequest;
+import com.lxp.aplus.progress.presentation.response.LearningHistoryResponse;
 import com.lxp.aplus.progress.presentation.response.ProgressUpdateResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProgressController {
 
     private final ProgressCommandUseCase progressCommandUseCase;
+    private final ProgressQueryUseCase progressQueryUseCase;
 
     @PatchMapping("/{enrollmentId}")
     public ResponseEntity<ResultResponse<ProgressUpdateResponse>> updateProgress(
@@ -31,7 +35,15 @@ public class ProgressController {
             @Valid @RequestBody ProgressUpdateRequest request
     ) {
         ProgressUpdateResponse response = progressCommandUseCase.updateProgress(currentUser, enrollmentId, request);
-
         return ResponseEntity.ok(ResultResponse.of(ProgressResultCode.UPDATE_PROGRESS_SUCCESS, response));
+    }
+
+    @GetMapping("/{enrollmentId}")
+    public ResponseEntity<ResultResponse<LearningHistoryResponse>> getLearningHistory(
+            @Authenticated UserInfo currentUser,
+            @PathVariable Long enrollmentId
+    ) {
+        LearningHistoryResult result = progressQueryUseCase.getLearningHistory(currentUser.id(), enrollmentId);
+        return ResponseEntity.ok(ResultResponse.of(ProgressResultCode.GET_PROGRESS_SUCCESS, LearningHistoryResponse.from(result)));
     }
 }

--- a/src/main/java/com/lxp/aplus/progress/presentation/controller/ProgressController.java
+++ b/src/main/java/com/lxp/aplus/progress/presentation/controller/ProgressController.java
@@ -44,6 +44,7 @@ public class ProgressController {
             @PathVariable Long enrollmentId
     ) {
         LearningHistoryResult result = progressQueryUseCase.getLearningHistory(currentUser.id(), enrollmentId);
-        return ResponseEntity.ok(ResultResponse.of(ProgressResultCode.GET_PROGRESS_SUCCESS, LearningHistoryResponse.from(result)));
+        return ResponseEntity.ok(ResultResponse
+                .of(ProgressResultCode.GET_PROGRESS_SUCCESS, LearningHistoryResponse.from(result)));
     }
 }

--- a/src/main/java/com/lxp/aplus/progress/presentation/response/LearningHistoryResponse.java
+++ b/src/main/java/com/lxp/aplus/progress/presentation/response/LearningHistoryResponse.java
@@ -1,0 +1,33 @@
+package com.lxp.aplus.progress.presentation.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.lxp.aplus.progress.application.result.LearningHistoryResult;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record LearningHistoryResponse(
+        Long enrollmentId,
+        int overallProgressRate,
+        Long lastWatchedVideoId,
+        Integer lastWatchedDurationOfLastVideo,
+        LocalDateTime lastWatchedAt,
+        List<LectureProgressResponse> lectureProgresses
+) {
+    public static LearningHistoryResponse from(LearningHistoryResult result) {
+        List<LectureProgressResponse> lectureProgresses = result.lectureProgresses().stream()
+                .map(LectureProgressResponse::from)
+                .collect(Collectors.toList());
+
+        return new LearningHistoryResponse(
+                result.enrollmentId(),
+                result.overallProgressRate(),
+                result.lastWatchedVideoId(),
+                result.lastWatchedDurationOfLastVideo(),
+                result.lastWatchedAt(),
+                lectureProgresses
+        );
+    }
+}

--- a/src/main/java/com/lxp/aplus/progress/presentation/response/LectureProgressResponse.java
+++ b/src/main/java/com/lxp/aplus/progress/presentation/response/LectureProgressResponse.java
@@ -1,0 +1,29 @@
+package com.lxp.aplus.progress.presentation.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.lxp.aplus.progress.application.result.LectureProgressResult;
+
+import java.time.LocalDateTime;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record LectureProgressResponse(
+        Long resourceId,
+        String title,
+        int currentProgressRate,
+        int watchedDuration,
+        int totalDurationSeconds,
+        boolean isCompleted,
+        LocalDateTime lastWatchedAt
+) {
+    public static LectureProgressResponse from(LectureProgressResult result) {
+        return new LectureProgressResponse(
+                result.resourceId(),
+                result.title(),
+                result.currentProgressRate(),
+                result.watchedDuration(),
+                result.totalDurationSeconds(),
+                result.isCompleted(),
+                result.lastWatchedAt()
+        );
+    }
+}

--- a/src/test/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentCommandUseCaseTest.java
+++ b/src/test/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentCommandUseCaseTest.java
@@ -16,10 +16,8 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import java.time.LocalDateTime;
 import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentQueryUseCaseTest.java
+++ b/src/test/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentQueryUseCaseTest.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.LongStream;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
@@ -162,8 +161,8 @@ class EnrollmentQueryUseCaseTest {
         assertThat(result.enrollmentId()).isEqualTo(enrollmentId);
         assertThat(result.studentId()).isEqualTo(studentId);
         assertThat(result.courseId()).isEqualTo(courseId);
-        assertThat(result.progressRate()).isEqualTo(40); // 4 / 10 * 100
-        assertThat(result.status()).isEqualTo(EnrollmentStatus.ENROLLED); // Default status
+        assertThat(result.progressRate()).isEqualTo(40);
+        assertThat(result.status()).isEqualTo(EnrollmentStatus.ENROLLED);
     }
 
     @Test

--- a/src/test/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentQueryUseCaseTest.java
+++ b/src/test/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentQueryUseCaseTest.java
@@ -21,7 +21,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/com/lxp/aplus/progress/application/usecase/ProgressCommandUseCaseTest.java
+++ b/src/test/java/com/lxp/aplus/progress/application/usecase/ProgressCommandUseCaseTest.java
@@ -22,11 +22,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;

--- a/src/test/java/com/lxp/aplus/progress/application/usecase/ProgressCommandUseCaseTest.java
+++ b/src/test/java/com/lxp/aplus/progress/application/usecase/ProgressCommandUseCaseTest.java
@@ -65,7 +65,7 @@ class ProgressCommandUseCaseTest {
         Long courseId = 100L;
 
         Enrollment enrollment = Enrollment.builder().id(enrollmentId).studentId(currentUser.id()).courseId(courseId).expiredAt(LocalDateTime.now().plusDays(1)).build();
-        Progress existingProgress = Progress.of(enrollment, lectureResource); // isCompleted = false
+        Progress existingProgress = Progress.of(enrollment, lectureResource);
 
         given(enrollmentRepository.findById(enrollmentId)).willReturn(Optional.of(enrollment));
         given(courseRepository.findAllLecturesWithResourcesByCourseId(courseId)).willReturn(List.of(lecture));

--- a/src/test/java/com/lxp/aplus/progress/application/usecase/ProgressQueryUseCaseTest.java
+++ b/src/test/java/com/lxp/aplus/progress/application/usecase/ProgressQueryUseCaseTest.java
@@ -1,0 +1,224 @@
+package com.lxp.aplus.progress.application.usecase;
+
+import com.lxp.aplus.common.error.BusinessException;
+import com.lxp.aplus.common.error.code.EnrollmentErrorCode;
+import com.lxp.aplus.common.error.code.ProgressErrorCode;
+import com.lxp.aplus.common.security.UserInfo;
+import com.lxp.aplus.enrollment.application.port.out.CourseFinder;
+import com.lxp.aplus.enrollment.application.port.out.LectureResourceSummary;
+import com.lxp.aplus.enrollment.domain.Enrollment;
+import com.lxp.aplus.enrollment.domain.EnrollmentRepository;
+import com.lxp.aplus.enrollment.domain.EnrollmentStatus;
+import com.lxp.aplus.progress.application.result.LearningHistoryResult;
+import com.lxp.aplus.progress.domain.Progress;
+import com.lxp.aplus.progress.domain.ProgressRepository;
+import com.lxp.aplus.user.domain.RoleType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import com.lxp.aplus.course.domain.LectureResource;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class ProgressQueryUseCaseTest {
+
+    @InjectMocks
+    private ProgressQueryUseCase progressQueryUseCase;
+
+    @Mock
+    private EnrollmentRepository enrollmentRepository;
+    @Mock
+    private CourseFinder courseFinder;
+    @Mock
+    private ProgressRepository progressRepository;
+
+    private UserInfo currentUser;
+    private Long STUDENT_ID = 10L;
+    private Long ENROLLMENT_ID = 1L;
+    private Long COURSE_ID = 100L;
+    private Long RESOURCE_ID_1 = 3001L;
+    private Long RESOURCE_ID_2 = 3002L;
+    private Long RESOURCE_ID_3 = 3003L;
+
+    @BeforeEach
+    void setUp() {
+        currentUser = new UserInfo(STUDENT_ID, List.of(RoleType.STUDENT));
+    }
+
+    @Test
+    @DisplayName("성공 - 학습 이력을 조회해야 한다.")
+    void getLearningHistory_success() {
+        // given
+        Enrollment enrollment = Enrollment.builder()
+                .id(ENROLLMENT_ID)
+                .studentId(STUDENT_ID)
+                .courseId(COURSE_ID)
+                .expiredAt(LocalDateTime.now().plusDays(1))
+                .status(EnrollmentStatus.ENROLLED)
+                .build();
+        ReflectionTestUtils.setField(enrollment, "createdAt", LocalDateTime.now().minusDays(10));
+
+        List<LectureResourceSummary> lectureResourceSummaries = List.of(
+                new LectureResourceSummary(RESOURCE_ID_1, "Spring Boot 개념 설명", 240),
+                new LectureResourceSummary(RESOURCE_ID_2, "Spring Data JPA 활용", 300),
+                new LectureResourceSummary(RESOURCE_ID_3, "RESTful API 설계", 180)
+        );
+        
+        LectureResource lr1 = mock(LectureResource.class);
+        given(lr1.getId()).willReturn(RESOURCE_ID_1);
+
+        LectureResource lr2 = mock(LectureResource.class);
+        given(lr2.getId()).willReturn(RESOURCE_ID_2);
+        
+        Progress progress1 = Progress.builder()
+                .enrollment(enrollment)
+                .lectureResource(lr1)
+                .watchedDuration(180)
+                .isCompleted(true)
+                .lastWatchedAt(LocalDateTime.now().minusHours(1))
+                .build();
+        
+        Progress progress2 = Progress.builder()
+                .enrollment(enrollment)
+                .lectureResource(lr2)
+                .watchedDuration(90)
+                .isCompleted(false)
+                .lastWatchedAt(LocalDateTime.now().minusHours(2))
+                .build();
+
+        List<Progress> progresses = List.of(progress1, progress2);
+
+        // Mocking
+        given(enrollmentRepository.findById(ENROLLMENT_ID)).willReturn(Optional.of(enrollment));
+        given(courseFinder.findAllLectureResourcesByCourseId(COURSE_ID)).willReturn(lectureResourceSummaries);
+        given(progressRepository.findByEnrollmentIdAndLectureResourceIds(any(Long.class), any(List.class)))
+                .willReturn(progresses);
+
+
+        // when
+        LearningHistoryResult result = progressQueryUseCase.getLearningHistory(currentUser.id(), ENROLLMENT_ID);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.enrollmentId()).isEqualTo(ENROLLMENT_ID);
+        assertThat(result.overallProgressRate()).isEqualTo(33);
+        
+        assertThat(result.lastWatchedVideoId()).isEqualTo(RESOURCE_ID_1);
+        assertThat(result.lastWatchedDurationOfLastVideo()).isEqualTo(180);
+        assertThat(result.lastWatchedAt()).isNotNull();
+
+        assertThat(result.lectureProgresses()).hasSize(3);
+        assertThat(result.lectureProgresses().get(0).resourceId()).isEqualTo(RESOURCE_ID_1);
+        assertThat(result.lectureProgresses().get(0).isCompleted()).isTrue();
+        assertThat(result.lectureProgresses().get(0).watchedDuration()).isEqualTo(180);
+        assertThat(result.lectureProgresses().get(0).currentProgressRate()).isEqualTo(75);
+
+        assertThat(result.lectureProgresses().get(1).resourceId()).isEqualTo(RESOURCE_ID_2);
+        assertThat(result.lectureProgresses().get(1).isCompleted()).isFalse();
+        assertThat(result.lectureProgresses().get(1).watchedDuration()).isEqualTo(90);
+        assertThat(result.lectureProgresses().get(1).currentProgressRate()).isEqualTo(30);
+
+        assertThat(result.lectureProgresses().get(2).resourceId()).isEqualTo(RESOURCE_ID_3);
+        assertThat(result.lectureProgresses().get(2).isCompleted()).isFalse();
+        assertThat(result.lectureProgresses().get(2).watchedDuration()).isEqualTo(0);
+        assertThat(result.lectureProgresses().get(2).currentProgressRate()).isEqualTo(0);
+    }
+    
+    @Test
+    @DisplayName("실패 - 수강 내역을 찾을 수 없을 때 예외를 발생시켜야 한다.")
+    void getLearningHistory_fail_enrollmentNotFound() {
+        // given
+        given(enrollmentRepository.findById(ENROLLMENT_ID)).willReturn(Optional.empty());
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> progressQueryUseCase.getLearningHistory(currentUser.id(), ENROLLMENT_ID));
+        assertThat(exception.getErrorCode()).isEqualTo(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND_OR_NO_ACCESS);
+    }
+
+    @Test
+    @DisplayName("실패 - 다른 학생의 수강 내역 조회 시 예외를 발생시켜야 한다.")
+    void getLearningHistory_fail_accessDenied() {
+        // given
+        Enrollment othersEnrollment = Enrollment.builder().id(ENROLLMENT_ID).studentId(STUDENT_ID + 1).build();
+        given(enrollmentRepository.findById(ENROLLMENT_ID)).willReturn(Optional.of(othersEnrollment));
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> progressQueryUseCase.getLearningHistory(currentUser.id(), ENROLLMENT_ID));
+        assertThat(exception.getErrorCode()).isEqualTo(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND_OR_NO_ACCESS);
+    }
+
+    @Test
+    @DisplayName("실패 - 수강 기간이 만료되었을 때 예외를 발생시켜야 한다.")
+    void getLearningHistory_fail_enrollmentExpired() {
+        // given
+        Enrollment expiredEnrollment = Enrollment.builder()
+                .id(ENROLLMENT_ID)
+                .studentId(STUDENT_ID)
+                .courseId(COURSE_ID)
+                .expiredAt(LocalDateTime.now().minusDays(1))
+                .build();
+        given(enrollmentRepository.findById(ENROLLMENT_ID)).willReturn(Optional.of(expiredEnrollment));
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> progressQueryUseCase.getLearningHistory(currentUser.id(), ENROLLMENT_ID));
+        assertThat(exception.getErrorCode()).isEqualTo(EnrollmentErrorCode.ENROLLMENT_EXPIRED_HISTORY_ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("실패 - 학습할 리소스가 없을 때 예외를 발생시켜야 한다.")
+    void getLearningHistory_fail_noResources() {
+        // given
+        Enrollment enrollment = Enrollment.builder()
+                .id(ENROLLMENT_ID)
+                .studentId(STUDENT_ID)
+                .courseId(COURSE_ID)
+                .expiredAt(LocalDateTime.now().plusDays(1))
+                .build();
+        given(enrollmentRepository.findById(ENROLLMENT_ID)).willReturn(Optional.of(enrollment));
+        given(courseFinder.findAllLectureResourcesByCourseId(COURSE_ID)).willReturn(Collections.emptyList());
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> progressQueryUseCase.getLearningHistory(currentUser.id(), ENROLLMENT_ID));
+        assertThat(exception.getErrorCode()).isEqualTo(ProgressErrorCode.LEARNING_HISTORY_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("실패 - 학습 이력이 없을 때 예외를 발생시켜야 한다. (아직 학습을 시작하지 않음)")
+    void getLearningHistory_fail_noProgressYet() {
+        // given
+        Enrollment enrollment = Enrollment.builder()
+                .id(ENROLLMENT_ID)
+                .studentId(STUDENT_ID)
+                .courseId(COURSE_ID)
+                .expiredAt(LocalDateTime.now().plusDays(1))
+                .build();
+        List<LectureResourceSummary> lectureResourceSummaries = List.of(
+                new LectureResourceSummary(RESOURCE_ID_1, "Spring Boot 개념 설명", 240)
+        );
+        
+        given(enrollmentRepository.findById(ENROLLMENT_ID)).willReturn(Optional.of(enrollment));
+        given(courseFinder.findAllLectureResourcesByCourseId(COURSE_ID)).willReturn(lectureResourceSummaries);
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> progressQueryUseCase.getLearningHistory(currentUser.id(), ENROLLMENT_ID));
+        assertThat(exception.getErrorCode()).isEqualTo(ProgressErrorCode.LEARNING_HISTORY_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/lxp/aplus/progress/application/usecase/ProgressQueryUseCaseTest.java
+++ b/src/test/java/com/lxp/aplus/progress/application/usecase/ProgressQueryUseCaseTest.java
@@ -2,7 +2,6 @@ package com.lxp.aplus.progress.application.usecase;
 
 import com.lxp.aplus.common.error.BusinessException;
 import com.lxp.aplus.common.error.code.EnrollmentErrorCode;
-import com.lxp.aplus.common.error.code.ProgressErrorCode;
 import com.lxp.aplus.common.security.UserInfo;
 import com.lxp.aplus.enrollment.application.port.out.CourseFinder;
 import com.lxp.aplus.enrollment.application.port.out.LectureResourceSummary;
@@ -24,11 +23,13 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 import com.lxp.aplus.course.domain.LectureResource;
 import static org.mockito.Mockito.mock;
 
@@ -187,17 +188,22 @@ class ProgressQueryUseCaseTest {
                 .expiredAt(LocalDateTime.now().plusDays(1))
                 .build();
         given(enrollmentRepository.findById(ENROLLMENT_ID)).willReturn(Optional.of(enrollment));
-        given(courseFinder.findAllLectureResourcesByCourseId(COURSE_ID)).willReturn(Collections.emptyList());
+        
+        List<LectureResourceSummary> emptyLectureResources = new ArrayList<>();
+        given(courseFinder.findAllLectureResourcesByCourseId(enrollment.getCourseId())).willReturn(emptyLectureResources); // enrollment.getCourseId()를 직접 사용
 
         // when
         LearningHistoryResult result = progressQueryUseCase.getLearningHistory(currentUser.id(), ENROLLMENT_ID);
 
         // then
+        verify(courseFinder).findAllLectureResourcesByCourseId(enrollment.getCourseId());
         assertThat(result).isNotNull();
         assertThat(result.enrollmentId()).isEqualTo(ENROLLMENT_ID);
         assertThat(result.overallProgressRate()).isEqualTo(0);
         assertThat(result.lectureProgresses()).isEmpty();
-        assertThat(result.lastWatchedVideoId()).isNull();
+        assertThat(result.lastWatchedVideoId()).isEqualTo(0L);
+        assertThat(result.lastWatchedDurationOfLastVideo()).isEqualTo(0);
+        assertThat(result.lastWatchedAt()).isNull();
     }
 
     @Test
@@ -217,7 +223,7 @@ class ProgressQueryUseCaseTest {
         given(enrollmentRepository.findById(ENROLLMENT_ID)).willReturn(Optional.of(enrollment));
         given(courseFinder.findAllLectureResourcesByCourseId(COURSE_ID)).willReturn(lectureResourceSummaries);
         given(progressRepository.findByEnrollmentIdAndLectureResourceIds(any(Long.class), any(List.class)))
-                .willReturn(Collections.emptyList()); // 진도 기록이 없음을 명시
+                .willReturn(Collections.emptyList());
 
         // when
         LearningHistoryResult result = progressQueryUseCase.getLearningHistory(currentUser.id(), ENROLLMENT_ID);
@@ -230,6 +236,8 @@ class ProgressQueryUseCaseTest {
         assertThat(result.lectureProgresses().get(0).resourceId()).isEqualTo(RESOURCE_ID_1);
         assertThat(result.lectureProgresses().get(0).currentProgressRate()).isEqualTo(0);
         assertThat(result.lectureProgresses().get(0).watchedDuration()).isEqualTo(0);
-        assertThat(result.lastWatchedVideoId()).isNull(); // 진도가 없으므로 마지막 시청 정보도 없음
+        assertThat(result.lastWatchedVideoId()).isEqualTo(0L);
+        assertThat(result.lastWatchedDurationOfLastVideo()).isEqualTo(0);
+        assertThat(result.lastWatchedAt()).isNull();
     }
 }

--- a/src/test/java/com/lxp/aplus/progress/application/usecase/ProgressQueryUseCaseTest.java
+++ b/src/test/java/com/lxp/aplus/progress/application/usecase/ProgressQueryUseCaseTest.java
@@ -74,30 +74,26 @@ class ProgressQueryUseCaseTest {
         List<LectureResourceSummary> lectureResourceSummaries = List.of(
                 new LectureResourceSummary(RESOURCE_ID_1, "Spring Boot 개념 설명", 240),
                 new LectureResourceSummary(RESOURCE_ID_2, "Spring Data JPA 활용", 300),
-                new LectureResourceSummary(RESOURCE_ID_3, "RESTful API 설계", 180)
+                new LectureResourceSummary(RESOURCE_ID_3, "RESTFul API 설계", 180)
         );
-        
-        LectureResource lr1 = mock(LectureResource.class);
-        given(lr1.getId()).willReturn(RESOURCE_ID_1);
 
-        LectureResource lr2 = mock(LectureResource.class);
-        given(lr2.getId()).willReturn(RESOURCE_ID_2);
-        
-        Progress progress1 = Progress.builder()
-                .enrollment(enrollment)
-                .lectureResource(lr1)
-                .watchedDuration(180)
-                .isCompleted(true)
-                .lastWatchedAt(LocalDateTime.now().minusHours(1))
-                .build();
-        
-        Progress progress2 = Progress.builder()
-                .enrollment(enrollment)
-                .lectureResource(lr2)
-                .watchedDuration(90)
-                .isCompleted(false)
-                .lastWatchedAt(LocalDateTime.now().minusHours(2))
-                .build();
+        Progress progress1 = mock(Progress.class);
+        LectureResource lr1_mock = mock(LectureResource.class);
+        given(lr1_mock.getId()).willReturn(RESOURCE_ID_1);
+        given(progress1.getLectureResource()).willReturn(lr1_mock);
+        given(progress1.getWatchedDuration()).willReturn(180);
+        given(progress1.isCompleted()).willReturn(true);
+        given(progress1.getLastWatchedAt()).willReturn(LocalDateTime.now().minusHours(1));
+        given(progress1.calculateProgressRate()).willReturn(75);
+
+        Progress progress2 = mock(Progress.class);
+        LectureResource lr2_mock = mock(LectureResource.class);
+        given(lr2_mock.getId()).willReturn(RESOURCE_ID_2);
+        given(progress2.getLectureResource()).willReturn(lr2_mock);
+        given(progress2.getWatchedDuration()).willReturn(90);
+        given(progress2.isCompleted()).willReturn(false);
+        given(progress2.getLastWatchedAt()).willReturn(LocalDateTime.now().minusHours(2));
+        given(progress2.calculateProgressRate()).willReturn(30);
 
         List<Progress> progresses = List.of(progress1, progress2);
 
@@ -181,8 +177,8 @@ class ProgressQueryUseCaseTest {
     }
 
     @Test
-    @DisplayName("실패 - 학습할 리소스가 없을 때 예외를 발생시켜야 한다.")
-    void getLearningHistory_fail_noResources() {
+    @DisplayName("성공 - 학습할 리소스가 없을 경우, 0% 진도로 빈 학습 이력을 반환해야 한다.")
+    void getLearningHistory_success_noResources() {
         // given
         Enrollment enrollment = Enrollment.builder()
                 .id(ENROLLMENT_ID)
@@ -193,15 +189,20 @@ class ProgressQueryUseCaseTest {
         given(enrollmentRepository.findById(ENROLLMENT_ID)).willReturn(Optional.of(enrollment));
         given(courseFinder.findAllLectureResourcesByCourseId(COURSE_ID)).willReturn(Collections.emptyList());
 
-        // when & then
-        BusinessException exception = assertThrows(BusinessException.class,
-                () -> progressQueryUseCase.getLearningHistory(currentUser.id(), ENROLLMENT_ID));
-        assertThat(exception.getErrorCode()).isEqualTo(ProgressErrorCode.LEARNING_HISTORY_NOT_FOUND);
+        // when
+        LearningHistoryResult result = progressQueryUseCase.getLearningHistory(currentUser.id(), ENROLLMENT_ID);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.enrollmentId()).isEqualTo(ENROLLMENT_ID);
+        assertThat(result.overallProgressRate()).isEqualTo(0);
+        assertThat(result.lectureProgresses()).isEmpty();
+        assertThat(result.lastWatchedVideoId()).isNull();
     }
 
     @Test
-    @DisplayName("실패 - 학습 이력이 없을 때 예외를 발생시켜야 한다. (아직 학습을 시작하지 않음)")
-    void getLearningHistory_fail_noProgressYet() {
+    @DisplayName("성공 - 학습 이력이 없을 경우, 0% 진도로 학습 이력을 반환해야 한다. (아직 학습을 시작하지 않음)")
+    void getLearningHistory_success_noProgressYet() {
         // given
         Enrollment enrollment = Enrollment.builder()
                 .id(ENROLLMENT_ID)
@@ -215,10 +216,20 @@ class ProgressQueryUseCaseTest {
         
         given(enrollmentRepository.findById(ENROLLMENT_ID)).willReturn(Optional.of(enrollment));
         given(courseFinder.findAllLectureResourcesByCourseId(COURSE_ID)).willReturn(lectureResourceSummaries);
+        given(progressRepository.findByEnrollmentIdAndLectureResourceIds(any(Long.class), any(List.class)))
+                .willReturn(Collections.emptyList()); // 진도 기록이 없음을 명시
 
-        // when & then
-        BusinessException exception = assertThrows(BusinessException.class,
-                () -> progressQueryUseCase.getLearningHistory(currentUser.id(), ENROLLMENT_ID));
-        assertThat(exception.getErrorCode()).isEqualTo(ProgressErrorCode.LEARNING_HISTORY_NOT_FOUND);
+        // when
+        LearningHistoryResult result = progressQueryUseCase.getLearningHistory(currentUser.id(), ENROLLMENT_ID);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.enrollmentId()).isEqualTo(ENROLLMENT_ID);
+        assertThat(result.overallProgressRate()).isEqualTo(0);
+        assertThat(result.lectureProgresses()).hasSize(1);
+        assertThat(result.lectureProgresses().get(0).resourceId()).isEqualTo(RESOURCE_ID_1);
+        assertThat(result.lectureProgresses().get(0).currentProgressRate()).isEqualTo(0);
+        assertThat(result.lectureProgresses().get(0).watchedDuration()).isEqualTo(0);
+        assertThat(result.lastWatchedVideoId()).isNull(); // 진도가 없으므로 마지막 시청 정보도 없음
     }
 }


### PR DESCRIPTION
## ✨ 요약
특정 수강 신청 내역(enrollmentId)에 대한 상세한 학습 이력을 조회하는 API (GET /api/progresses/{enrollmentId})를 구현했습니다. 이 API는 사용자가 가장 마지막으로 시청했던 강의 정보("이어보기" 기능)와 함께, 강좌의 전체 진도율 및 개별 강의별 상세 진도 목록을 제공합니다. 요청한 사용자의 수강 내역 소유권 검증 및 만료 여부 확인 등 보안 및 유효성 검증 로직이 포함되어 있습니다.

## 📝 작업 내용
- API 엔드포인트 구현 (ProgressController) -GET /api/progresses/{enrollmentId} 엔드포인트를 추가
인증된 사용자(currentUser.id())와 enrollmentId를 받아 ProgressQueryUseCase를 호출하고 LearningHistoryResponse 형태로 결과를 반환.


- 비즈니스 로직 구현 (ProgressQueryUseCase)
Enrollment 조회 및 enrollment.validateOwner(), enrollment.isExpired() 검증 로직을 수행
CourseFinder (확장됨)를 통해 강좌에 포함된 모든 LectureResourceSummary(강의 제목, 총 재생 시간 포함) 목록을 가져옵니다.
ProgressRepository (확장됨)를 통해 해당 수강 내역에 대한 Progress 정보를 조회합니다.
모든 정보를 조합하여 전체 진도율(overallProgressRate), 마지막으로 시청한 영상 정보(lastWatchedVideoId, lastWatchedDurationOfLastVideo, lastWatchedAt), 그리고 개별 강의별 진도 상세 목록(lectureProgresses)을 계산하고 LearningHistoryResult 형태로 반환

- 데이터 전송 객체 (DTO) 정의
Application Layer (record 타입): LearningHistoryResult, LectureProgressResult를 정의
Presentation Layer (record 타입): LearningHistoryResponse, LectureProgressResponse를 정의했으며, null 값을 JSON에서 제외하도록 @JsonInclude(JsonInclude.Include.NON_NULL)을 적용

- CourseFinder 확장 및 구현
enrollment 모듈 내 CourseFinder 인터페이스에 List<LectureResourceSummary> findAllLectureResourcesByCourseId(Long courseId); 메서드를 추가했습니다.
CourseFinder의 구현체인 CourseFinderAdapter에 해당 메서드를 구현하여 courseRepository를 통해 데이터를 조회하고 LectureResourceSummary DTO 리스트로 변환합니다.
이는 course 모듈의 직접적인 수정 없이 필요한 정보를 가져오는 포트/어댑터 패턴을 따릅니다.

- ProgressRepository 확장 및 구현
ProgressRepository 인터페이스에 Map<Long, Boolean> getCompletionStatusMap(Long enrollmentId, List<Long> lectureResourceIds); 메서드를 추가했습니다.
ProgressRepositoryImpl에 해당 메서드를 구현하여 Progress 엔티티 리스트를 Map<ResourceId, isCompleted> 형태로 효율적으로 변환합니다.
ProgressJpaRepository의 findByEnrollment_IdAndLectureResource_IdIn 메서드에 @Query와 FETCH JOIN을 추가하여 LectureResource를 함께 Eager 로딩하도록 개선, LazyInitializationException 발생 가능성을 제거했습니다.

## 💭 주의 사항
CourseFinderAdapter의 findAllLectureResourcesByCourseId 메서드에서 @Transactional(readOnly = true) 어노테이션이 사용되었습니다. 이는 데이터베이스 조회 시 지연 로딩되는 엔티티 관계를 안전하게 가져오기 위한 필수적인 트랜잭션 설정입니다.

## 💡 리뷰 포인트
아키텍처 원칙 준수: course 모듈을 직접 수정하지 않고 CourseFinder (포트/어댑터 패턴)를 확장하여 필요한 데이터를 가져온 방식이 적절한지 검토 부탁드립니다. 특히 CourseFinderAdapter에서 Lecture 엔티티를 통해 title과 totalDurationSeconds를 가져오는 방식이 course 도메인 내의 정보 흐름에 적합한지 확인 부탁드립니다.
복합 데이터 조합 로직: ProgressQueryUseCase에서 Enrollment, Course (Finder를 통해), Progress 데이터를 조합하여 복잡한 응답 DTO(LearningHistoryResult)를 구성하는 로직의 효율성과 가독성을 확인 부탁드립니다.
이어보기 기능 구현: lastWatchedAt을 기준으로 가장 최근의 진도 정보를 추출하는 로직의 정확성을 검토 부탁드립니다.

## ✅ 테스트
- [x] 로컬 빌드/실행
- [x] 단위 테스트 추가/통과
- [ ] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
<img width="998" height="333" alt="image" src="https://github.com/user-attachments/assets/f0774e2c-76e6-4e01-a661-22f383a261f3" />
