### PR TITLE
[FEAT] 강좌별 수강 정보 조회 API 구현 (수강 여부 확인) && 강좌별 학습 이력 조회 API 구현(By Course ID) && 강좌별 진도율 갱신 API 구현 (By Course ID), 내 수강 목록 조회 Api에 카테고리 보이게 추가

### DIFF
--- a/http/enrollment.http
+++ b/http/enrollment.http
@@ -1,0 +1,74 @@
+### API HTTP Client
+### IntelliJ에서 직접 실행 가능 (▶ 버튼 클릭)
+### 변수 설정: baseUrl, accessToken, refreshToken 등
+
+### 변수 설정 (실행 전에 수정 가능)
+@baseUrl = http://localhost:8080
+@contentType = application/json
+# 로그인 API 실행 후 아래 토큰은 자동으로 채워집니다.
+@accessToken =
+@refreshToken =
+
+### 테스트용 데이터 (실행 전에 수정 가능)
+### 실제 DB에 존재하는 유효한 ID로 변경해야 합니다.
+@testCourseId = 1
+@testEnrollmentId = 1
+
+
+##########################################
+### 사전 준비: 인증 (Auth)
+### 다른 .http 파일에서 이미 로그인했다면 이 단계를 건너뛰어도 됩니다.
+##########################################
+
+### 1. 회원가입 (테스트용 사용자 생성)
+# @name signup
+POST {{baseUrl}}/api/auth/signup
+Content-Type: {{contentType}}
+
+{
+  "nickname": "ㅁㅁㅁ",
+  "email": "test@example.com",
+  "password": "password123"
+}
+
+### 로그인 (테스트 전 필수)
+# @name login
+POST {{baseUrl}}/api/auth/login
+Content-Type: {{contentType}}
+
+{
+  "email": "test@example.com",
+  "password": "password123"
+}
+
+> {%
+    client.global.set("accessToken", response.body.data.accessToken);
+    client.global.set("refreshToken", response.body.data.refreshToken);
+    client.log("Access Token: " + response.body.data.accessToken);
+%}
+
+### 로그인 확인 (내 정보 조회)
+GET {{baseUrl}}/api/users/me
+Authorization: Bearer {{accessToken}}
+
+
+###
+##########################################
+### 수강(Enrollment) API (/api/enrollments)
+##########################################
+
+### 1. 내 수강 목록 조회 (카테고리 포함)
+# status: ENROLLED(수강중), COMPLETED(수강완료)
+GET {{baseUrl}}/api/enrollments?status=ENROLLED&page=0&size=10
+Authorization: Bearer {{accessToken}}
+
+###
+### 2. 수강 정보 단건 상세 조회 (by Enrollment ID)
+GET {{baseUrl}}/api/enrollments/{{testEnrollmentId}}
+Authorization: Bearer {{accessToken}}
+
+###
+### 3. 강좌별 수강 정보 조회 (by Course ID)
+# 상세 페이지 등에서 enrollmentId를 모를 때 사용
+GET {{baseUrl}}/api/enrollments/course/{{testCourseId}}
+Authorization: Bearer {{accessToken}}

--- a/http/progress.http
+++ b/http/progress.http
@@ -1,0 +1,81 @@
+### API HTTP Client
+### IntelliJ에서 직접 실행 가능 (▶ 버튼 클릭)
+### 변수 설정: baseUrl, accessToken, refreshToken 등
+
+### 변수 설정 (실행 전에 수정 가능)
+@baseUrl = http://localhost:8080
+@contentType = application/json
+# 로그인 API 실행 후 아래 토큰은 자동으로 채워집니다.
+@accessToken =
+@refreshToken =
+
+### 테스트용 데이터 (실행 전에 수정 가능)
+### 실제 DB에 존재하는 유효한 ID로 변경해야 합니다.
+@testCourseId = 1
+@testEnrollmentId = 1
+@testResourceId = 1
+
+
+##########################################
+### 사전 준비: 인증 (Auth)
+### 다른 .http 파일에서 이미 로그인했다면 이 단계를 건너뛰어도 됩니다.
+##########################################
+
+### 로그인 (테스트 전 필수)
+# @name login
+POST {{baseUrl}}/api/auth/login
+Content-Type: {{contentType}}
+
+{
+  "email": "test@example.com",
+  "password": "password123"
+}
+
+> {%
+    client.global.set("accessToken", response.body.data.accessToken);
+    client.global.set("refreshToken", response.body.data.refreshToken);
+    client.log("Access Token: " + response.body.data.accessToken);
+%}
+
+### 로그인 확인 (내 정보 조회)
+GET {{baseUrl}}/api/users/me
+Authorization: Bearer {{accessToken}}
+
+
+###
+##########################################
+### 진도(Progress) API (/api/progresses)
+##########################################
+
+### 1. 학습 이력 상세 조회 (by Enrollment ID)
+GET {{baseUrl}}/api/progresses/{{testEnrollmentId}}
+Authorization: Bearer {{accessToken}}
+
+###
+### 2. 강좌별 학습 이력 조회 (by Course ID)
+# enrollmentId를 모를 때 사용
+GET {{baseUrl}}/api/progresses/course/{{testCourseId}}
+Authorization: Bearer {{accessToken}}
+
+###
+### 3. 진도율 갱신 (by Enrollment ID)
+PATCH {{baseUrl}}/api/progresses/{{testEnrollmentId}}
+Content-Type: {{contentType}}
+Authorization: Bearer {{accessToken}}
+
+{
+  "resourceId": {{testResourceId}},
+  "watchedDuration": 180
+}
+
+###
+### 4. 강좌별 진도율 갱신 (by Course ID)
+# enrollmentId를 모를 때 사용
+PATCH {{baseUrl}}/api/progresses/course/{{testCourseId}}
+Content-Type: {{contentType}}
+Authorization: Bearer {{accessToken}}
+
+{
+  "resourceId": {{testResourceId}},
+  "watchedDuration": 200
+}

--- a/src/main/java/com/lxp/aplus/enrollment/application/port/out/CourseFinder.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/port/out/CourseFinder.java
@@ -7,5 +7,7 @@ public interface CourseFinder {
     Optional<CourseSummary> findCourseById(Long courseId);
     int countLectures(Long courseId);
     List<Long> getLectureResourceIds(Long courseId);
-    List<LectureResourceSummary> findAllLectureResourcesByCourseId(Long courseId);
-}
+        List<LectureResourceSummary> findAllLectureResourcesByCourseId(Long courseId);
+        List<String> findCategoryNamesByCourseId(Long courseId);
+    }
+    

--- a/src/main/java/com/lxp/aplus/enrollment/application/result/EnrollmentListItemResult.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/result/EnrollmentListItemResult.java
@@ -1,5 +1,8 @@
 package com.lxp.aplus.enrollment.application.result;
 
+import java.util.List;
+
+
 import com.lxp.aplus.enrollment.domain.Enrollment;
 import com.lxp.aplus.enrollment.application.port.out.CourseSummary;
 import com.lxp.aplus.enrollment.domain.EnrollmentStatus;
@@ -10,15 +13,17 @@ public record EnrollmentListItemResult(
         Long enrollmentId,
         Long courseId,
         String courseName,
+        List<String> categories,
         EnrollmentStatus status,
         int progressRate,
         LocalDateTime expiredAt
 ) {
-    public static EnrollmentListItemResult of(Enrollment enrollment, CourseSummary courseSummary, int progressRate) {
+    public static EnrollmentListItemResult of(Enrollment enrollment, CourseSummary courseSummary, int progressRate, List<String> categories) {
         return new EnrollmentListItemResult(
                 enrollment.getId(),
                 enrollment.getCourseId(),
                 courseSummary.courseName(),
+                categories,
                 enrollment.getStatus(),
                 progressRate,
                 enrollment.getExpiredAt()

--- a/src/main/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentQueryUseCase.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentQueryUseCase.java
@@ -38,13 +38,16 @@ public class EnrollmentQueryUseCase {
                 .map(enrollment -> {
                     CourseSummary courseSummary = courseFinder.findCourseById(enrollment.getCourseId())
                             .orElseThrow(() -> new BusinessException(CourseErrorCode.COURSE_NOT_FOUND));
+                    
+                    List<String> categoryNames = courseFinder.findCategoryNamesByCourseId(enrollment.getCourseId());
 
                     List<Long> lectureResourceIds = courseFinder.getLectureResourceIds(enrollment.getCourseId());
                     if (lectureResourceIds.isEmpty()) {
                         return EnrollmentListItemResult.of(
                                 enrollment,
                                 courseSummary,
-                                0
+                                0,
+                                categoryNames
                         );
                     }
 
@@ -58,7 +61,8 @@ public class EnrollmentQueryUseCase {
                     return EnrollmentListItemResult.of(
                             enrollment,
                             courseSummary,
-                            progressRate
+                            progressRate,
+                            categoryNames
                     );
                 })
                 .collect(Collectors.toList());
@@ -86,9 +90,26 @@ public class EnrollmentQueryUseCase {
         return EnrollmentDetailResult.of(enrollment, progressRate);
     }
 
+    public EnrollmentDetailResult getEnrollmentDetailByCourseId(Long studentId, Long courseId) {
+        Enrollment enrollment = enrollmentRepository.findByStudentIdAndCourseId(studentId, courseId)
+                .orElseThrow(() -> new BusinessException(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND_OR_NO_ACCESS));
 
+        List<Long> lectureResourceIds = courseFinder.getLectureResourceIds(enrollment.getCourseId());
+        int progressRate = 0;
+        if (!lectureResourceIds.isEmpty()) {
+            Map<Long, Boolean> resourceIdToIsCompletedMap = progressFinder.getCompletionStatusMap(enrollment.getId(), lectureResourceIds);
+            long completedResources = resourceIdToIsCompletedMap.values()
+                                                                .stream()
+                                                                .filter(Boolean::booleanValue)
+                                                                .count();
+            progressRate = (int) ((double) completedResources / lectureResourceIds.size() * 100);
+        }
+
+        return EnrollmentDetailResult.of(enrollment, progressRate);
+    }
 
     public long getStudentCountForCourse(Long courseId) {
         return enrollmentRepository.countByCourseId(courseId);
     }
 }
+

--- a/src/main/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentQueryUseCase.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentQueryUseCase.java
@@ -50,18 +50,18 @@ public class EnrollmentQueryUseCase {
                                 categoryNames
                         );
                     }
-
+                    long totalResourceCount = lectureResourceIds.size();
                     Map<Long, Boolean> resourceIdToIsCompletedMap = progressFinder.getCompletionStatusMap(enrollment.getId(), lectureResourceIds);
-                    long completedResources = resourceIdToIsCompletedMap.values()
+                    long completedResourceCount = resourceIdToIsCompletedMap.values()
                                                                         .stream()
                                                                         .filter(Boolean::booleanValue)
                                                                         .count();
-                    int progressRate = (int) ((double) completedResources / lectureResourceIds.size() * 100);
+                    int completionPercentage = (int) ((double) completedResourceCount / totalResourceCount * 100);
 
                     return EnrollmentListItemResult.of(
                             enrollment,
                             courseSummary,
-                            progressRate,
+                            completionPercentage,
                             categoryNames
                     );
                 })
@@ -77,17 +77,18 @@ public class EnrollmentQueryUseCase {
         enrollment.validateOwner(studentId);
 
         List<Long> lectureResourceIds = courseFinder.getLectureResourceIds(enrollment.getCourseId());
-        int progressRate = 0;
+        int completionPercentage = 0;
         if (!lectureResourceIds.isEmpty()) {
+            long totalResourceCount = lectureResourceIds.size();
             Map<Long, Boolean> resourceIdToIsCompletedMap = progressFinder.getCompletionStatusMap(enrollment.getId(), lectureResourceIds);
-            long completedResources = resourceIdToIsCompletedMap.values()
+            long completedResourceCount = resourceIdToIsCompletedMap.values()
                                                                 .stream()
                                                                 .filter(Boolean::booleanValue)
                                                                 .count();
-            progressRate = (int) ((double) completedResources / lectureResourceIds.size() * 100);
+            completionPercentage = (int) ((double) completedResourceCount / totalResourceCount * 100);
         }
 
-        return EnrollmentDetailResult.of(enrollment, progressRate);
+        return EnrollmentDetailResult.of(enrollment, completionPercentage);
     }
 
     public EnrollmentDetailResult getEnrollmentDetailByCourseId(Long studentId, Long courseId) {
@@ -95,17 +96,18 @@ public class EnrollmentQueryUseCase {
                 .orElseThrow(() -> new BusinessException(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND_OR_NO_ACCESS));
 
         List<Long> lectureResourceIds = courseFinder.getLectureResourceIds(enrollment.getCourseId());
-        int progressRate = 0;
+        int completionPercentage = 0;
         if (!lectureResourceIds.isEmpty()) {
+            long totalResourceCount = lectureResourceIds.size();
             Map<Long, Boolean> resourceIdToIsCompletedMap = progressFinder.getCompletionStatusMap(enrollment.getId(), lectureResourceIds);
-            long completedResources = resourceIdToIsCompletedMap.values()
+            long completedResourceCount = resourceIdToIsCompletedMap.values()
                                                                 .stream()
                                                                 .filter(Boolean::booleanValue)
                                                                 .count();
-            progressRate = (int) ((double) completedResources / lectureResourceIds.size() * 100);
+            completionPercentage = (int) ((double) completedResourceCount / totalResourceCount * 100);
         }
 
-        return EnrollmentDetailResult.of(enrollment, progressRate);
+        return EnrollmentDetailResult.of(enrollment, completionPercentage);
     }
 
     public long getStudentCountForCourse(Long courseId) {

--- a/src/main/java/com/lxp/aplus/enrollment/infrastructure/adapter/CourseFinderAdapter.java
+++ b/src/main/java/com/lxp/aplus/enrollment/infrastructure/adapter/CourseFinderAdapter.java
@@ -1,52 +1,181 @@
 package com.lxp.aplus.enrollment.infrastructure.adapter;
 
+import com.lxp.aplus.category.domain.Category;
+
+import com.lxp.aplus.category.domain.CategoryRepository;
+
 import com.lxp.aplus.course.domain.CourseRepository;
+
 import com.lxp.aplus.enrollment.application.port.out.CourseFinder;
+
 import com.lxp.aplus.enrollment.application.port.out.CourseSummary;
+
 import com.lxp.aplus.enrollment.application.port.out.LectureResourceSummary;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Component;
+
 import org.springframework.transaction.annotation.Transactional;
+
+
+
+import java.util.ArrayList;
+
+import java.util.Collections;
+
 import java.util.List;
+
 import java.util.Optional;
+
 import java.util.stream.Collectors;
 
+
+
 @Component
+
 @RequiredArgsConstructor
+
 public class CourseFinderAdapter implements CourseFinder {
+
+
 
     private final CourseRepository courseRepository;
 
+    private final CategoryRepository categoryRepository;
+
+
+
     @Override
+
     @Transactional(readOnly = true)
+
     public Optional<CourseSummary> findCourseById(Long courseId) {
+
         return courseRepository.findById(courseId)
+
                 .map(course -> new CourseSummary(course.getId(), course.getTitle()));
+
     }
 
+
+
     @Override
+
     public int countLectures(Long courseId) {
+
         return courseRepository.countLecturesByCourseId(courseId);
+
     }
 
+
+
     @Override
+
     public List<Long> getLectureResourceIds(Long courseId) {
+
         return courseRepository.findAllLecturesWithResourcesByCourseId(courseId).stream()
+
                 .flatMap(lecture -> lecture.getLectureResources().stream())
+
                 .map(lectureResource -> lectureResource.getId())
+
                 .collect(Collectors.toList());
+
     }
 
+
+
     @Override
+
     @Transactional(readOnly = true)
+
     public List<LectureResourceSummary> findAllLectureResourcesByCourseId(Long courseId) {
+
         return courseRepository.findAllLecturesWithResourcesByCourseId(courseId).stream()
+
                 .flatMap(lecture -> lecture.getLectureResources().stream())
+
                 .map(resource -> new LectureResourceSummary(
+
                         resource.getId(),
+
                         resource.getLecture().getTitle(),
+
                         resource.getLecture().getTotalDurationSeconds()
+
                 ))
+
                 .collect(Collectors.toList());
+
     }
+
+
+
+        @Override
+
+
+
+        @Transactional(readOnly = true)
+
+
+
+        public List<String> findCategoryNamesByCourseId(Long courseId) {
+
+
+
+            return courseRepository.findById(courseId)
+
+
+
+                    .flatMap(course -> categoryRepository.findByIdWithParent(course.getCategoryId()))
+
+
+
+                    .map(category -> {
+
+
+
+                        List<String> categoryNames = new ArrayList<>();
+
+
+
+                        Category currentCategory = category;
+
+
+
+                        while (currentCategory != null) {
+
+
+
+                            categoryNames.add(currentCategory.getName());
+
+
+
+                            currentCategory = currentCategory.getParent();
+
+
+
+                        }
+
+
+
+                        Collections.reverse(categoryNames);
+
+
+
+                        return categoryNames;
+
+
+
+                    })
+
+
+
+                    .orElse(Collections.emptyList());
+
+
+
+        }
+
 }

--- a/src/main/java/com/lxp/aplus/enrollment/infrastructure/adapter/CourseFinderAdapter.java
+++ b/src/main/java/com/lxp/aplus/enrollment/infrastructure/adapter/CourseFinderAdapter.java
@@ -9,7 +9,7 @@ import com.lxp.aplus.enrollment.application.port.out.LectureResourceSummary;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -69,14 +69,12 @@ public class CourseFinderAdapter implements CourseFinder {
             return courseRepository.findById(courseId)
                     .flatMap(course -> categoryRepository.findByIdWithParent(course.getCategoryId()))
                     .map(category -> {
-                        List<String> categoryNames = new ArrayList<>();
+                        List<String> categoryNames = new LinkedList<>();
                         Category currentCategory = category;
                         while (currentCategory != null) {
-                            categoryNames.add(currentCategory.getName());
+                            categoryNames.add(0, currentCategory.getName());
                             currentCategory = currentCategory.getParent();
                         }
-                        Collections.reverse(categoryNames);
-
                         return categoryNames;
                     })
                     .orElse(Collections.emptyList());

--- a/src/main/java/com/lxp/aplus/enrollment/infrastructure/adapter/CourseFinderAdapter.java
+++ b/src/main/java/com/lxp/aplus/enrollment/infrastructure/adapter/CourseFinderAdapter.java
@@ -1,181 +1,85 @@
 package com.lxp.aplus.enrollment.infrastructure.adapter;
 
 import com.lxp.aplus.category.domain.Category;
-
 import com.lxp.aplus.category.domain.CategoryRepository;
-
 import com.lxp.aplus.course.domain.CourseRepository;
-
 import com.lxp.aplus.enrollment.application.port.out.CourseFinder;
-
 import com.lxp.aplus.enrollment.application.port.out.CourseSummary;
-
 import com.lxp.aplus.enrollment.application.port.out.LectureResourceSummary;
-
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.stereotype.Component;
-
 import org.springframework.transaction.annotation.Transactional;
-
-
-
 import java.util.ArrayList;
-
 import java.util.Collections;
-
 import java.util.List;
-
 import java.util.Optional;
-
 import java.util.stream.Collectors;
 
 
-
 @Component
-
 @RequiredArgsConstructor
-
 public class CourseFinderAdapter implements CourseFinder {
 
-
-
     private final CourseRepository courseRepository;
-
     private final CategoryRepository categoryRepository;
 
-
-
     @Override
-
     @Transactional(readOnly = true)
-
     public Optional<CourseSummary> findCourseById(Long courseId) {
 
         return courseRepository.findById(courseId)
-
                 .map(course -> new CourseSummary(course.getId(), course.getTitle()));
-
     }
 
 
 
     @Override
-
     public int countLectures(Long courseId) {
-
         return courseRepository.countLecturesByCourseId(courseId);
-
     }
 
 
 
     @Override
-
     public List<Long> getLectureResourceIds(Long courseId) {
-
         return courseRepository.findAllLecturesWithResourcesByCourseId(courseId).stream()
-
                 .flatMap(lecture -> lecture.getLectureResources().stream())
-
                 .map(lectureResource -> lectureResource.getId())
-
                 .collect(Collectors.toList());
-
     }
 
 
 
     @Override
-
     @Transactional(readOnly = true)
-
     public List<LectureResourceSummary> findAllLectureResourcesByCourseId(Long courseId) {
-
         return courseRepository.findAllLecturesWithResourcesByCourseId(courseId).stream()
-
                 .flatMap(lecture -> lecture.getLectureResources().stream())
-
                 .map(resource -> new LectureResourceSummary(
-
                         resource.getId(),
-
                         resource.getLecture().getTitle(),
-
                         resource.getLecture().getTotalDurationSeconds()
-
                 ))
-
                 .collect(Collectors.toList());
-
     }
-
-
 
         @Override
-
-
-
         @Transactional(readOnly = true)
-
-
-
         public List<String> findCategoryNamesByCourseId(Long courseId) {
-
-
-
             return courseRepository.findById(courseId)
-
-
-
                     .flatMap(course -> categoryRepository.findByIdWithParent(course.getCategoryId()))
-
-
-
                     .map(category -> {
-
-
-
                         List<String> categoryNames = new ArrayList<>();
-
-
-
                         Category currentCategory = category;
-
-
-
                         while (currentCategory != null) {
-
-
-
                             categoryNames.add(currentCategory.getName());
-
-
-
                             currentCategory = currentCategory.getParent();
-
-
-
                         }
-
-
-
                         Collections.reverse(categoryNames);
 
-
-
                         return categoryNames;
-
-
-
                     })
-
-
-
                     .orElse(Collections.emptyList());
-
-
-
         }
 
 }

--- a/src/main/java/com/lxp/aplus/enrollment/presentation/controller/EnrollmentController.java
+++ b/src/main/java/com/lxp/aplus/enrollment/presentation/controller/EnrollmentController.java
@@ -50,4 +50,15 @@ public class EnrollmentController {
                 ResultResponse.of(EnrollmentResultCode.GET_ENROLLMENT_DETAIL_SUCCESS, EnrollmentDetailResponse.from(result))
         );
     }
+
+    @GetMapping("/course/{courseId}")
+    public ResponseEntity<ResultResponse<EnrollmentDetailResponse>> getEnrollmentDetailByCourseId(
+            @Authenticated UserInfo currentUser,
+            @PathVariable Long courseId
+    ) {
+        EnrollmentDetailResult result = enrollmentQueryUseCase.getEnrollmentDetailByCourseId(currentUser.id(), courseId);
+        return ResponseEntity.ok(
+                ResultResponse.of(EnrollmentResultCode.GET_ENROLLMENT_DETAIL_SUCCESS, EnrollmentDetailResponse.from(result))
+        );
+    }
 }

--- a/src/main/java/com/lxp/aplus/progress/application/usecase/ProgressCommandUseCase.java
+++ b/src/main/java/com/lxp/aplus/progress/application/usecase/ProgressCommandUseCase.java
@@ -72,4 +72,11 @@ public class ProgressCommandUseCase {
 
         return ProgressUpdateResponse.of(savedProgress, currentProgressRate);
     }
+
+    public ProgressUpdateResponse updateProgressByCourseId(UserInfo currentUser, Long courseId, ProgressUpdateRequest request) {
+        Enrollment enrollment = enrollmentRepository.findByStudentIdAndCourseId(currentUser.id(), courseId)
+                .orElseThrow(() -> new BusinessException(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND_OR_NO_ACCESS));
+
+        return updateProgress(currentUser, enrollment.getId(), request);
+    }
 }

--- a/src/main/java/com/lxp/aplus/progress/application/usecase/ProgressQueryUseCase.java
+++ b/src/main/java/com/lxp/aplus/progress/application/usecase/ProgressQueryUseCase.java
@@ -88,6 +88,13 @@ public class ProgressQueryUseCase {
         );
     }
 
+    public LearningHistoryResult getLearningHistoryByCourseId(Long studentId, Long courseId) {
+        Enrollment enrollment = enrollmentRepository.findByStudentIdAndCourseId(studentId, courseId)
+                .orElseThrow(() -> new BusinessException(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND_OR_NO_ACCESS));
+
+        return getLearningHistory(studentId, enrollment.getId());
+    }
+
     private LectureProgressResult createLectureProgressResult(LectureResourceSummary resourceSummary, Map<Long, Progress> progressMap) {
         Progress progress = progressMap.get(resourceSummary.resourceId());
         int watchedDuration = progress != null ? progress.getWatchedDuration() : 0;

--- a/src/main/java/com/lxp/aplus/progress/presentation/controller/ProgressController.java
+++ b/src/main/java/com/lxp/aplus/progress/presentation/controller/ProgressController.java
@@ -47,4 +47,24 @@ public class ProgressController {
         return ResponseEntity.ok(ResultResponse
                 .of(ProgressResultCode.GET_PROGRESS_SUCCESS, LearningHistoryResponse.from(result)));
     }
+
+    @GetMapping("/course/{courseId}")
+    public ResponseEntity<ResultResponse<LearningHistoryResponse>> getLearningHistoryByCourseId(
+            @Authenticated UserInfo currentUser,
+            @PathVariable Long courseId
+    ) {
+        LearningHistoryResult result = progressQueryUseCase.getLearningHistoryByCourseId(currentUser.id(), courseId);
+        return ResponseEntity.ok(ResultResponse
+                .of(ProgressResultCode.GET_PROGRESS_SUCCESS, LearningHistoryResponse.from(result)));
+    }
+
+    @PatchMapping("/course/{courseId}")
+    public ResponseEntity<ResultResponse<ProgressUpdateResponse>> updateProgressByCourseId(
+            @Authenticated UserInfo currentUser,
+            @PathVariable Long courseId,
+            @Valid @RequestBody ProgressUpdateRequest request
+    ) {
+        ProgressUpdateResponse response = progressCommandUseCase.updateProgressByCourseId(currentUser, courseId, request);
+        return ResponseEntity.ok(ResultResponse.of(ProgressResultCode.UPDATE_PROGRESS_SUCCESS, response));
+    }
 }

--- a/src/test/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentQueryUseCaseTest.java
+++ b/src/test/java/com/lxp/aplus/enrollment/application/usecase/EnrollmentQueryUseCaseTest.java
@@ -60,12 +60,14 @@ class EnrollmentQueryUseCaseTest {
 
         Enrollment enrollment1 = Enrollment.of(STUDENT_ID, COURSE_ID_1, LocalDateTime.now().plusYears(1));
         ReflectionTestUtils.setField(enrollment1, "id", 5001L);
+        List<String> categories1 = List.of("프로그래밍", "백엔드");
 
         List<Long> resourceIds1 = LongStream.rangeClosed(1, 10).boxed().toList();
         Map<Long, Boolean> completionMap1 = Map.of(1L, true, 2L, true, 3L, true, 4L, true);
 
         Enrollment enrollment2 = Enrollment.of(STUDENT_ID, COURSE_ID_2, LocalDateTime.now().plusYears(1));
         ReflectionTestUtils.setField(enrollment2, "id", 5002L);
+        List<String> categories2 = List.of("프로그래밍", "프론트엔드");
         
         List<Long> resourceIds2 = LongStream.rangeClosed(11, 30).boxed().toList();
         Map<Long, Boolean> completionMap2 = Map.of(11L, true, 12L, true, 13L, true, 14L, true, 15L, true, 16L, true, 17L, true);
@@ -79,6 +81,9 @@ class EnrollmentQueryUseCaseTest {
                 .willReturn(Optional.of(new CourseSummary(COURSE_ID_1, COURSE_NAME_1)));
         given(courseFinder.findCourseById(COURSE_ID_2))
                 .willReturn(Optional.of(new CourseSummary(COURSE_ID_2, COURSE_NAME_2)));
+
+        given(courseFinder.findCategoryNamesByCourseId(COURSE_ID_1)).willReturn(categories1);
+        given(courseFinder.findCategoryNamesByCourseId(COURSE_ID_2)).willReturn(categories2);
 
         given(courseFinder.getLectureResourceIds(COURSE_ID_1)).willReturn(resourceIds1);
         given(courseFinder.getLectureResourceIds(COURSE_ID_2)).willReturn(resourceIds2);
@@ -96,10 +101,12 @@ class EnrollmentQueryUseCaseTest {
         EnrollmentListItemResult result1 = result.getContent().get(0);
         assertThat(result1.courseId()).isEqualTo(COURSE_ID_1);
         assertThat(result1.progressRate()).isEqualTo(40);
+        assertThat(result1.categories()).containsExactly("프로그래밍", "백엔드");
 
         EnrollmentListItemResult result2 = result.getContent().get(1);
         assertThat(result2.courseId()).isEqualTo(COURSE_ID_2);
         assertThat(result2.progressRate()).isEqualTo(35);
+        assertThat(result2.categories()).containsExactly("프로그래밍", "프론트엔드");
     }
 
     @Test
@@ -196,6 +203,51 @@ class EnrollmentQueryUseCaseTest {
         // when & then
         BusinessException exception = assertThrows(BusinessException.class,
                 () -> enrollmentQueryUseCase.getEnrollmentDetail(requestingStudentId, enrollmentId));
+        assertThat(exception.getErrorCode()).isEqualTo(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND_OR_NO_ACCESS);
+    }
+
+    @Test
+    @DisplayName("성공 - courseId로 수강 상세 정보를 조회해야 한다.")
+    void getEnrollmentDetailByCourseId_success() {
+        // given
+        Long studentId = STUDENT_ID;
+        Long courseId = COURSE_ID_1;
+        Long enrollmentId = 5001L;
+
+        Enrollment enrollment = Enrollment.of(studentId, courseId, LocalDateTime.now().plusYears(1));
+        ReflectionTestUtils.setField(enrollment, "id", enrollmentId);
+
+        List<Long> lectureResourceIds = LongStream.rangeClosed(1, 10).boxed().toList();
+        Map<Long, Boolean> completionMap = Map.of(1L, true, 2L, true, 3L, true, 4L, true);
+
+        given(enrollmentRepository.findByStudentIdAndCourseId(studentId, courseId)).willReturn(Optional.of(enrollment));
+        given(courseFinder.getLectureResourceIds(courseId)).willReturn(lectureResourceIds);
+        given(progressFinder.getCompletionStatusMap(enrollmentId, lectureResourceIds)).willReturn(completionMap);
+
+        // when
+        EnrollmentDetailResult result = enrollmentQueryUseCase.getEnrollmentDetailByCourseId(studentId, courseId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.enrollmentId()).isEqualTo(enrollmentId);
+        assertThat(result.studentId()).isEqualTo(studentId);
+        assertThat(result.courseId()).isEqualTo(courseId);
+        assertThat(result.progressRate()).isEqualTo(40);
+        assertThat(result.status()).isEqualTo(EnrollmentStatus.ENROLLED);
+    }
+
+    @Test
+    @DisplayName("실패 - courseId로 조회 시 수강 내역이 없으면 ENROLLMENT_NOT_FOUND_OR_NO_ACCESS 예외를 던져야 한다.")
+    void getEnrollmentDetailByCourseId_fail_notFound() {
+        // given
+        Long studentId = STUDENT_ID;
+        Long courseId = 9999L;
+
+        given(enrollmentRepository.findByStudentIdAndCourseId(studentId, courseId)).willReturn(Optional.empty());
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> enrollmentQueryUseCase.getEnrollmentDetailByCourseId(studentId, courseId));
         assertThat(exception.getErrorCode()).isEqualTo(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND_OR_NO_ACCESS);
     }
 }

--- a/src/test/java/com/lxp/aplus/progress/application/usecase/ProgressCommandUseCaseTest.java
+++ b/src/test/java/com/lxp/aplus/progress/application/usecase/ProgressCommandUseCaseTest.java
@@ -236,6 +236,61 @@ class ProgressCommandUseCaseTest {
 
         // when & then
         BusinessException exception = assertThrows(BusinessException.class, () -> progressCommandUseCase.updateProgress(currentUser, enrollmentId, request));
-        assertThat(exception.getErrorCode()).isEqualTo(ProgressErrorCode.WATCHED_DURATION_EXCEEDS_TOTAL);
-    }
-}
+                assertThat(exception.getErrorCode()).isEqualTo(ProgressErrorCode.WATCHED_DURATION_EXCEEDS_TOTAL);
+            }
+        
+            @Test
+            @DisplayName("성공 - courseId로 진도율을 갱신한다")
+            void updateProgressByCourseId_success() {
+                // given
+                Long resourceId = 1L;
+                Long courseId = 100L;
+                Long enrollmentId = 1L;
+        
+                Enrollment enrollment = Enrollment.builder().id(enrollmentId).studentId(currentUser.id()).courseId(courseId).expiredAt(LocalDateTime.now().plusDays(1)).build();
+                Progress existingProgress = Progress.of(enrollment, lectureResource);
+        
+                // Mocking for the new method
+                given(enrollmentRepository.findByStudentIdAndCourseId(currentUser.id(), courseId)).willReturn(Optional.of(enrollment));
+        
+                // Mocking for the original updateProgress method that gets called internally
+                given(enrollmentRepository.findById(enrollmentId)).willReturn(Optional.of(enrollment)); 
+                given(courseRepository.findAllLecturesWithResourcesByCourseId(courseId)).willReturn(List.of(lecture));
+                given(progressRepository.findByEnrollmentAndLectureResource(enrollment, lectureResource)).willReturn(Optional.of(existingProgress));
+                
+                when(lecture.getLectureResources()).thenReturn(List.of(lectureResource));
+                when(lectureResource.getId()).thenReturn(resourceId);
+                when(lectureResource.getLecture()).thenReturn(lecture);
+                when(lecture.getTotalDurationSeconds()).thenReturn(300);
+        
+                given(progressRepository.save(any(Progress.class))).willAnswer(invocation -> invocation.getArgument(0));
+                
+                // when
+                ProgressUpdateRequest request = new ProgressUpdateRequest(resourceId, 150);
+                ProgressUpdateResponse response = progressCommandUseCase.updateProgressByCourseId(currentUser, courseId, request);
+        
+                // then
+                ArgumentCaptor<Progress> progressCaptor = ArgumentCaptor.forClass(Progress.class);
+                verify(progressRepository).save(progressCaptor.capture());
+                Progress savedProgress = progressCaptor.getValue();
+        
+                assertThat(response).isNotNull();
+                assertThat(savedProgress.getWatchedDuration()).isEqualTo(150);
+                assertThat(response.progressRate()).isEqualTo(50);
+            }
+        
+            @Test
+            @DisplayName("실패 - courseId로 갱신 시 수강 내역이 없으면 예외를 발생시킨다")
+            void updateProgressByCourseId_fail_enrollmentNotFound() {
+                // given
+                Long courseId = 999L;
+                ProgressUpdateRequest request = new ProgressUpdateRequest(1L, 150);
+                given(enrollmentRepository.findByStudentIdAndCourseId(currentUser.id(), courseId)).willReturn(Optional.empty());
+        
+                // when & then
+                BusinessException exception = assertThrows(BusinessException.class, 
+                    () -> progressCommandUseCase.updateProgressByCourseId(currentUser, courseId, request));
+                assertThat(exception.getErrorCode()).isEqualTo(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND_OR_NO_ACCESS);
+            }
+        }
+        

--- a/src/test/java/com/lxp/aplus/progress/application/usecase/ProgressCommandUseCaseTest.java
+++ b/src/test/java/com/lxp/aplus/progress/application/usecase/ProgressCommandUseCaseTest.java
@@ -250,11 +250,8 @@ class ProgressCommandUseCaseTest {
                 Enrollment enrollment = Enrollment.builder().id(enrollmentId).studentId(currentUser.id()).courseId(courseId).expiredAt(LocalDateTime.now().plusDays(1)).build();
                 Progress existingProgress = Progress.of(enrollment, lectureResource);
         
-                // Mocking for the new method
                 given(enrollmentRepository.findByStudentIdAndCourseId(currentUser.id(), courseId)).willReturn(Optional.of(enrollment));
-        
-                // Mocking for the original updateProgress method that gets called internally
-                given(enrollmentRepository.findById(enrollmentId)).willReturn(Optional.of(enrollment)); 
+                given(enrollmentRepository.findById(enrollmentId)).willReturn(Optional.of(enrollment));
                 given(courseRepository.findAllLecturesWithResourcesByCourseId(courseId)).willReturn(List.of(lecture));
                 given(progressRepository.findByEnrollmentAndLectureResource(enrollment, lectureResource)).willReturn(Optional.of(existingProgress));
                 

--- a/src/test/java/com/lxp/aplus/progress/application/usecase/ProgressQueryUseCaseTest.java
+++ b/src/test/java/com/lxp/aplus/progress/application/usecase/ProgressQueryUseCaseTest.java
@@ -190,7 +190,7 @@ class ProgressQueryUseCaseTest {
         given(enrollmentRepository.findById(ENROLLMENT_ID)).willReturn(Optional.of(enrollment));
         
         List<LectureResourceSummary> emptyLectureResources = new ArrayList<>();
-        given(courseFinder.findAllLectureResourcesByCourseId(enrollment.getCourseId())).willReturn(emptyLectureResources); // enrollment.getCourseId()를 직접 사용
+        given(courseFinder.findAllLectureResourcesByCourseId(enrollment.getCourseId())).willReturn(emptyLectureResources);
 
         // when
         LearningHistoryResult result = progressQueryUseCase.getLearningHistory(currentUser.id(), ENROLLMENT_ID);
@@ -238,6 +238,79 @@ class ProgressQueryUseCaseTest {
         assertThat(result.lectureProgresses().get(0).watchedDuration()).isEqualTo(0);
         assertThat(result.lastWatchedVideoId()).isEqualTo(0L);
         assertThat(result.lastWatchedDurationOfLastVideo()).isEqualTo(0);
-        assertThat(result.lastWatchedAt()).isNull();
+                assertThat(result.lastWatchedAt()).isNull();
+            }
+
+    @Test
+    @DisplayName("성공 - courseId로 학습 이력을 조회해야 한다.")
+    void getLearningHistoryByCourseId_success() {
+        // given
+        Enrollment enrollment = Enrollment.builder()
+                .id(ENROLLMENT_ID)
+                .studentId(STUDENT_ID)
+                .courseId(COURSE_ID)
+                .expiredAt(LocalDateTime.now().plusDays(1))
+                .status(EnrollmentStatus.ENROLLED)
+                .build();
+        ReflectionTestUtils.setField(enrollment, "createdAt", LocalDateTime.now().minusDays(10));
+
+        List<LectureResourceSummary> lectureResourceSummaries = List.of(
+                new LectureResourceSummary(RESOURCE_ID_1, "Spring Boot 개념 설명", 240),
+                new LectureResourceSummary(RESOURCE_ID_2, "Spring Data JPA 활용", 300)
+        );
+
+        Progress progress1 = mock(Progress.class);
+        LectureResource lr1_mock = mock(LectureResource.class);
+        given(lr1_mock.getId()).willReturn(RESOURCE_ID_1);
+        given(progress1.getLectureResource()).willReturn(lr1_mock);
+        given(progress1.getWatchedDuration()).willReturn(180);
+        given(progress1.isCompleted()).willReturn(true);
+        given(progress1.getLastWatchedAt()).willReturn(LocalDateTime.now().minusHours(1));
+        given(progress1.calculateProgressRate()).willReturn(75);
+
+        List<Progress> progresses = List.of(progress1);
+
+        // Mocking
+        given(enrollmentRepository.findByStudentIdAndCourseId(STUDENT_ID, COURSE_ID)).willReturn(Optional.of(enrollment));
+        given(enrollmentRepository.findById(ENROLLMENT_ID)).willReturn(Optional.of(enrollment));
+
+        given(courseFinder.findAllLectureResourcesByCourseId(COURSE_ID)).willReturn(lectureResourceSummaries);
+        given(progressRepository.findByEnrollmentIdAndLectureResourceIds(any(Long.class), any(List.class)))
+                .willReturn(progresses);
+
+        // when
+        LearningHistoryResult result = progressQueryUseCase.getLearningHistoryByCourseId(STUDENT_ID, COURSE_ID);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.enrollmentId()).isEqualTo(ENROLLMENT_ID);
+        assertThat(result.overallProgressRate()).isEqualTo(50); // 1 completed out of 2 resources
+        
+        assertThat(result.lastWatchedVideoId()).isEqualTo(RESOURCE_ID_1);
+        assertThat(result.lastWatchedDurationOfLastVideo()).isEqualTo(180);
+        assertThat(result.lastWatchedAt()).isNotNull();
+
+        assertThat(result.lectureProgresses()).hasSize(2);
+        assertThat(result.lectureProgresses().get(0).resourceId()).isEqualTo(RESOURCE_ID_1);
+        assertThat(result.lectureProgresses().get(0).isCompleted()).isTrue();
+        assertThat(result.lectureProgresses().get(0).watchedDuration()).isEqualTo(180);
+        assertThat(result.lectureProgresses().get(0).currentProgressRate()).isEqualTo(75);
+
+        assertThat(result.lectureProgresses().get(1).resourceId()).isEqualTo(RESOURCE_ID_2);
+        assertThat(result.lectureProgresses().get(1).isCompleted()).isFalse();
+        assertThat(result.lectureProgresses().get(1).watchedDuration()).isEqualTo(0);
+        assertThat(result.lectureProgresses().get(1).currentProgressRate()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("실패 - courseId로 조회 시 수강 내역이 없으면 ENROLLMENT_NOT_FOUND_OR_NO_ACCESS 예외를 던져야 한다.")
+    void getLearningHistoryByCourseId_fail_enrollmentNotFound() {
+        // given
+        given(enrollmentRepository.findByStudentIdAndCourseId(STUDENT_ID, COURSE_ID)).willReturn(Optional.empty());
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> progressQueryUseCase.getLearningHistoryByCourseId(STUDENT_ID, COURSE_ID));
+        assertThat(exception.getErrorCode()).isEqualTo(EnrollmentErrorCode.ENROLLMENT_NOT_FOUND_OR_NO_ACCESS);
     }
 }


### PR DESCRIPTION
## ✨ 요약
 - enrollmentId 없이 courseId만으로 수강 정보 조회, 학습 이력 조회, 진도율 갱신이 가능하도록 courseId 기반의 신규 API 3종을 구현했습니다.
 - 이를 통해 프론트엔드에서 강좌 상세 페이지 진입 시 불필요한 API 호출을 줄이고, 페이지 새로고침 등에도 안정적으로 대응할 수 있도록 편의성과 효율성을 높였습니다.
 - 추가적으로, 프론트엔드 팀원의 요청에 따라 내 수강 목록 조회 API의 응답에 강좌의 전체 카테고리 경로가 포함되도록 개선했습니다.

## 📝 작업 내용
신규 API 구현
   1. 강좌별 수강 정보 조회 API (수강 여부 확인)
       - GET /api/enrollments/course/{courseId}
       - courseId와 인증 토큰을 사용해 enrollmentId 등 수강 정보를 반환합니다.
   2. 강좌별 학습 이력 조회 API
       - GET /api/progresses/course/{courseId}
       - courseId만으로 상세 학습 이력과 이어보기 정보를 조회합니다.
   3. 강좌별 진도율 갱신 API
       - PATCH /api/progresses/course/{courseId}
       - courseId만으로 특정 강의의 시청 기록(진도율)을 갱신합니다.

기존 API 개선
   1. 내 수강 목록 조회 API (`GET /api/enrollments`)
       - 응답 데이터(EnrollmentListItemResult)에 categories 필드를 추가했습니다.
       - Course에 설정된 categoryId를 통해 최상위 카테고리까지의 전체 경로(예: ["프로그래밍", "백엔드"])가 배열로 반환되도록 조회 로직을 구현했습니다.

리팩토링 및 테스트
   - 신규 API들은 기존 UseCase의 로직을 재사용하는 방향으로 구현하여 코드 중복을 최소화했습니다.
   - CourseFinder 포트와 CourseFinderAdapter 어댑터를 확장하여 카테고리 조회 책임을 분리했습니다.
   - 추가 및 수정된 모든 기능에 대해 단위 테스트 코드를 작성하여 안정성을 확보했습니다.
## 💭 주의 사항

## 💡 리뷰 포인트
 - courseId 기반으로 새로 추가된 3개 API의 설계가 일관성 있고 RESTful한지 확인 부탁드립니다.
   - CourseFinderAdapter에 구현된 카테고리 계층 조회 로직이 효율적이고 정확한지 확인 부탁드립니다.
   - 기존 UseCase의 메소드를 재사용하여 중복을 최소화한 접근 방식이 적절한지 리뷰 부탁드립니다.
   - 
## ✅ 테스트
- [x] 로컬 빌드/실행
- [x] 단위 테스트 추가/통과
- [ ] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
<img width="998" height="333" alt="image" src="https://github.com/user-attachments/assets/bff38323-2b0e-4641-9fc7-417a0f2bca2a" />

<img width="998" height="333" alt="image" src="https://github.com/user-attachments/assets/32d37e6a-73dd-4fe7-a0ef-d28cccc505d7" />

<img width="998" height="333" alt="image" src="https://github.com/user-attachments/assets/2495c070-3232-49e4-a091-ab1f344995b1" />
