### PR TITLE
[FEAT] auth annotation 권한 체크 수정

### DIFF
--- a/src/main/java/com/lxp/aplus/common/security/CorsConfig.java
+++ b/src/main/java/com/lxp/aplus/common/security/CorsConfig.java
@@ -1,0 +1,41 @@
+package com.lxp.aplus.common.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsFilter corsFilter() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        // 프론트 주소 허용 (필요한 주소 추가)
+        config.setAllowedOrigins(List.of(
+                "http://localhost:3000",
+                "http://127.0.0.1:3000"
+        ));
+
+        // 모든 HTTP 메서드 허용
+        config.setAllowedMethods(List.of("*"));
+
+        // 모든 헤더 허용
+        config.setAllowedHeaders(List.of("*"));
+
+        // 쿠키/Authorization 헤더 사용시 필요
+        config.setAllowCredentials(true);
+
+        // preflight 캐시
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return new CorsFilter(source);
+    }
+}

--- a/src/main/java/com/lxp/aplus/common/security/CurrentUser.java
+++ b/src/main/java/com/lxp/aplus/common/security/CurrentUser.java
@@ -9,16 +9,24 @@ import java.lang.annotation.Target;
  * 현재 로그인한 사용자 정보를 메서드 파라미터로 주입받는 어노테이션
  * 
  * 이 어노테이션이 붙은 파라미터는 인증된 사용자의 정보가 자동으로 주입됩니다.
- * 인증되지 않은 경우 UNAUTHORIZED 예외가 발생합니다.
+ * 인증되지 않은 경우 null이 반환됩니다. (예외 발생하지 않음)
+ * 
+ * 선택적 인증이 필요한 경우에 사용합니다.
+ * 필수 인증이 필요한 경우에는 @Authenticated를 사용하세요.
  * 
  * 사용 예시:
  * <pre>
  * {@code
  * @GetMapping("/courses")
  * public ResponseEntity<CourseResponse> getCourses(@CurrentUser UserInfo userInfo) {
+ *     if (userInfo == null) {
+ *         // 비로그인 사용자 처리
+ *         return ResponseEntity.ok(getPublicCourses());
+ *     }
+ *     // 로그인 사용자 처리
  *     Long userId = userInfo.id();
  *     List<RoleType> roles = userInfo.roles();
- *     // ...
+ *     return ResponseEntity.ok(getUserCourses(userId));
  * }
  * }
  * </pre>

--- a/src/main/java/com/lxp/aplus/common/security/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/lxp/aplus/common/security/CurrentUserArgumentResolver.java
@@ -1,7 +1,5 @@
 package com.lxp.aplus.common.security;
 
-import com.lxp.aplus.common.error.BusinessException;
-import com.lxp.aplus.common.error.code.GlobalErrorCode;
 import com.lxp.aplus.user.domain.Role;
 import com.lxp.aplus.user.domain.RoleType;
 import com.lxp.aplus.user.domain.User;
@@ -15,11 +13,13 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * @CurrentUser 어노테이션이 붙은 파라미터에 현재 로그인한 사용자 정보를 주입하는 Resolver
  * 
- * 인증되지 않은 사용자가 접근하면 UNAUTHORIZED 예외를 발생시킵니다.
+ * 인증되지 않은 사용자가 접근하면 null을 반환합니다. (예외 발생하지 않음)
+ * 선택적 인증이 필요한 경우에 사용합니다.
  */
 @Component
 @RequiredArgsConstructor
@@ -42,21 +42,26 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
         
         Long userId = SecurityUtils.getCurrentUserId();
         
+        // 사용자가 없으면 null 반환 (예외 발생하지 않음)
         if (userId == null) {
-            throw new BusinessException(GlobalErrorCode.UNAUTHORIZED);
+            return null;
         }
 
         // 사용자와 역할 정보 조회
-        User user = userRepository.findUserWithRolesById(userId)
-                .orElseThrow(() -> new BusinessException(com.lxp.aplus.common.error.code.UserErrorCode.USER_NOT_FOUND));
+        Optional<User> user = userRepository.findUserWithRolesById(userId);
+        
+        // 사용자를 찾을 수 없으면 null 반환
+        if (user == null) {
+            return null;
+        }
 
         // Role 목록 추출 (삭제되지 않은 Role만)
-        List<RoleType> roles = user.getRoles().stream()
+        List<RoleType> roles = user.get().getRoles().stream()
                 .filter(role -> role.getDeletedAt() == null)
                 .map(Role::getRoleType)
                 .toList();
 
-        return new UserInfo(user.getId(), roles);
+        return new UserInfo(userId, roles);
     }
 }
 

--- a/src/main/java/com/lxp/aplus/common/security/InstructorOnlyAspect.java
+++ b/src/main/java/com/lxp/aplus/common/security/InstructorOnlyAspect.java
@@ -11,13 +11,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.stereotype.Component;
 
-import java.util.Arrays;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 
 /**
  * @InstructorOnly 어노테이션을 처리하는 AOP Aspect
- * 
+ * <p>
  * 메서드 실행 전에 강사 권한을 체크합니다.
  */
 @Slf4j
@@ -32,7 +34,7 @@ public class InstructorOnlyAspect {
     public void checkInstructorRole(JoinPoint joinPoint) {
         // 메서드 파라미터에서 @Authenticated로 주입된 userId 찾기
         Object[] args = joinPoint.getArgs();
-        Long userId = findUserIdFromArgs(args);
+        Long userId = findUserId(joinPoint);
 
         if (userId == null) {
             log.warn("@InstructorOnly 메서드에 @Authenticated 파라미터가 없습니다: {}", joinPoint.getSignature());
@@ -47,7 +49,7 @@ public class InstructorOnlyAspect {
                 .anyMatch(role -> role.getRoleType() == RoleType.INSTRUCTOR && role.getDeletedAt() == null);
 
         if (!hasInstructorRole) {
-            log.warn("강사 권한이 없는 사용자가 강사 전용 메서드에 접근 시도: userId={}, method={}", 
+            log.warn("강사 권한이 없는 사용자가 강사 전용 메서드에 접근 시도: userId={}, method={}",
                     userId, joinPoint.getSignature());
             throw new BusinessException(UserErrorCode.NOT_INSTRUCTOR);
         }
@@ -55,16 +57,29 @@ public class InstructorOnlyAspect {
 
     /**
      * 메서드 파라미터에서 Long 타입의 userId를 찾습니다.
-     * 
+     *
      * @param args 메서드 파라미터 배열
      * @return userId (없으면 null)
      */
-    private Long findUserIdFromArgs(Object[] args) {
-        return Arrays.stream(args)
-                .filter(arg -> arg instanceof Long)
-                .map(arg -> (Long) arg)
-                .findFirst()
-                .orElse(null);
+    private Long findUserId(JoinPoint joinPoint) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        Object[] args = joinPoint.getArgs();
+        Annotation[][] parameterAnnotations = method.getParameterAnnotations();
+        for (int i = 0; i < args.length; i++) {
+            for (Annotation annotation : parameterAnnotations[i]) {
+                if (annotation instanceof Authenticated) {
+                    Object arg = args[i]; // 1. Long 타입인 경우 (userId)
+                    if (arg instanceof Long) {
+                        return (Long) arg;
+                    } // 2. UserInfo 타입인 경우(userInfo.id())
+                    if (arg instanceof UserInfo) {
+                        return ((UserInfo) arg).id();
+                    }
+                }
+            }
+        }
+        return null;
     }
 }
 

--- a/src/main/java/com/lxp/aplus/common/security/SecurityConfig.java
+++ b/src/main/java/com/lxp/aplus/common/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -27,7 +28,9 @@ public class SecurityConfig {
         http
                 // CSRF 비활성화 (JWT 사용 시 불필요)
                 .csrf(AbstractHttpConfigurer::disable)
-                
+                .csrf(csrf -> csrf.disable())               // API 서버는 대부분 disable
+                .cors(Customizer.withDefaults())            // 반드시 포함!
+
                 // 세션 사용 안 함 (JWT 사용)
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/src/main/java/com/lxp/aplus/user/application/dto/UserResponse.java
+++ b/src/main/java/com/lxp/aplus/user/application/dto/UserResponse.java
@@ -11,9 +11,9 @@ import java.util.List;
 public record UserResponse(
         Long id,
         String name,
-        String nickName,
+        String nickname,
         String email,
-        String phoneNumber,
+        String phonenumber,
         UserStatus status,
         List<RoleType> roles,
         LocalDateTime createdAt,


### PR DESCRIPTION
### ✨ 요약
Auth 관련 권한 체크 로직을 수정하여 로그인하지 않은 사용자도 특정 엔드포인트에 접근 가능하도록 허용했습니다.

### 📝 작업 내용
@Auth 어노테이션 옵션에 인증 선택(optional) 개념 추가
기존에 로그인 필수로 처리되던 구간을 optional 권한 범위로 변경
Interceptor / ArgumentResolver 내부 권한 검증 로직 수정
인증이 없어도 정상 동작하도록 예외 분기 추가
관련 테스트 코드 보완 및 리팩터링

### 💭 주의 사항
프론트엔드에서 Authorization 헤더 없이 요청이 들어올 수 있으므로 문서화 필요
이후 권한 정책 정비 시 optional 엔드포인트 목록이 중복되거나 누락되지 않도록 관리 필요

### 💡 리뷰 포인트
기본 권한 정책이 깨지지 않았는지
향후 다른 권한 타입과의 확장성 관점에서 이 구조가 적절한지

### ✅ 테스트
 -[] 로컬 빌드/실행
 -[] 단위 테스트 추가/통과
 -[] API 수동 테스트 (인증 O / 인증 X 요청 모두 확인)

📸 참고(스크린샷 / API 예시)

(필요 시 추가)