### PR TITLE
[FIX] 결제 완료 후 수강 권한 부여 기능 추가

### DIFF
--- a/src/main/java/com/lxp/aplus/payment/application/port/out/EnrollmentCommandPort.java
+++ b/src/main/java/com/lxp/aplus/payment/application/port/out/EnrollmentCommandPort.java
@@ -1,0 +1,14 @@
+package com.lxp.aplus.payment.application.port.out;
+
+import java.util.List;
+
+public interface EnrollmentCommandPort {
+
+    /*
+     * 특정 사용자에게 구매 강좌에 대한 수강 권한을 동기적으로 부여한다.
+     * TODO: 나중에 이벤트로 비동기 처리하도록 리팩터
+     * @param userId 수강을 요청하는 사용자 ID
+     * @param courseIds 수강권 부여의 근거가 된 주문 ID 목록
+     */
+    void enrollUserInCourses(Long userId, List<Long> courseIds);
+}

--- a/src/main/java/com/lxp/aplus/payment/application/port/out/OrderQueryPort.java
+++ b/src/main/java/com/lxp/aplus/payment/application/port/out/OrderQueryPort.java
@@ -1,0 +1,11 @@
+package com.lxp.aplus.payment.application.port.out;
+
+import java.util.List;
+
+public interface OrderQueryPort {
+
+    /*
+     * OrderLine ID(= courseId) 조회
+     */
+    List<Long> getCourseIdsByOrderId(String orderId);
+}

--- a/src/main/java/com/lxp/aplus/payment/application/usecase/PaymentCommandUseCase.java
+++ b/src/main/java/com/lxp/aplus/payment/application/usecase/PaymentCommandUseCase.java
@@ -2,6 +2,8 @@ package com.lxp.aplus.payment.application.usecase;
 
 import com.lxp.aplus.common.error.BusinessException;
 import com.lxp.aplus.common.error.code.PaymentErrorCode;
+import com.lxp.aplus.payment.application.port.out.EnrollmentCommandPort;
+import com.lxp.aplus.payment.application.port.out.OrderQueryPort;
 import com.lxp.aplus.payment.application.result.OrderCreateResult;
 import com.lxp.aplus.payment.application.command.PaymentConfirmCommand;
 import com.lxp.aplus.payment.application.command.PaymentPrepareCommand;
@@ -13,6 +15,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -20,6 +24,8 @@ public class PaymentCommandUseCase {
 
     private final PaymentRepository paymentRepository;
     private final OrderCommandPort orderCommandPort;
+    private final OrderQueryPort orderQueryPort;
+    private final EnrollmentCommandPort enrollmentCommandPort;
 
     public PaymentPrepareResponse prepare(PaymentPrepareCommand command) {
 
@@ -57,5 +63,11 @@ public class PaymentCommandUseCase {
 
         // 5. Payment 저장
         paymentRepository.save(payment);
+
+        List<Long> courseIds = orderQueryPort.getCourseIdsByOrderId(command.orderId());
+
+        // 6. 수강 권한 부여
+        // TODO: 향후 이벤트로 처리
+        enrollmentCommandPort.enrollUserInCourses(command.userId(), courseIds);
     }
 }

--- a/src/main/java/com/lxp/aplus/payment/infrastructure/adapter/EnrollmentCommandAdapter.java
+++ b/src/main/java/com/lxp/aplus/payment/infrastructure/adapter/EnrollmentCommandAdapter.java
@@ -1,0 +1,50 @@
+package com.lxp.aplus.payment.infrastructure.adapter;
+
+import com.lxp.aplus.enrollment.domain.Enrollment;
+import com.lxp.aplus.enrollment.domain.EnrollmentRepository;
+import com.lxp.aplus.payment.application.port.out.EnrollmentCommandPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * EnrollmentCommandPort의 구현체 (Adapter)
+ * // TODO: 향후 이 메서드 내용은 Enrollment BC에서 구현하여 전달받도록 리팩터해야 합니다.
+ */
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class EnrollmentCommandAdapter implements EnrollmentCommandPort {
+
+    private final EnrollmentRepository enrollmentRepository;
+
+    @Override
+    public void enrollUserInCourses(Long userId, List<Long> courseIds) {
+
+        // 1. 중복 수강 여부 확인 -> Enrollment 생성
+        // TODO: Enrollment 도메인 규칙으로 이동
+        List<Enrollment> newEnrollments = new ArrayList<>();
+
+        for (Long courseId : courseIds) {
+            boolean isEnrolled = enrollmentRepository.existsByStudentIdAndCourseId(userId, courseId);
+
+            if (!isEnrolled) {
+                Enrollment enrollment = Enrollment.of(
+                        userId,
+                        courseId,
+                        LocalDateTime.now().plusYears(2)
+                );
+
+                newEnrollments.add(enrollment);
+            }
+        }
+
+        // 3. Enrollment 저장
+        // FIXME: 이 트랜잭션이 실패하면 Payment 트랜잭션도 롤백되는 문제 -> 추후 이벤트로 수정!! 🚨
+        enrollmentRepository.saveAll(newEnrollments);
+    }
+}

--- a/src/main/java/com/lxp/aplus/payment/infrastructure/adapter/OrderQueryAdapter.java
+++ b/src/main/java/com/lxp/aplus/payment/infrastructure/adapter/OrderQueryAdapter.java
@@ -1,0 +1,40 @@
+package com.lxp.aplus.payment.infrastructure.adapter;
+
+import com.lxp.aplus.common.error.BusinessException;
+import com.lxp.aplus.common.error.code.OrderErrorCode;
+import com.lxp.aplus.order.domain.Order;
+import com.lxp.aplus.order.domain.OrderLine;
+import com.lxp.aplus.order.domain.OrderRepository;
+import com.lxp.aplus.payment.application.port.out.OrderQueryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * OrderQueryPort의 구현체 (Adapter)
+ */
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderQueryAdapter implements OrderQueryPort {
+
+    // 💡 Order BC의 Repository를 주입받아 Order Aggregate Root에 접근합니다.
+    private final OrderRepository orderRepository;
+
+    @Override
+    public List<Long> getCourseIdsByOrderId(String orderId) {
+
+        // 1. Order Aggregate Root 조회
+        // Order는 OrderLine 컬렉션을 가지고 있으므로, fetch join 등으로 함께 로딩되어야 합니다.
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        // 2. OrderLine 목록에서 courseId 추출 및 반환
+        return order.getOrderLines().stream()
+                .map(OrderLine::getItemId)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ✨ 요약

- 결제 완료 API에서 결제 승인 후 Enrollment를 생성하여 수강 권한을 줄 수 있도록 했습니다.

## 📝 작업 내용

- Payment BC -> Enrollment BC : 수강 생성 (EnrollmentCommandPort)
- Payment BC -> Order BC : 주문 강좌 조회 (OrderQueryPort)
- Port & Adapter
- Command Port = 상태 변경 Port
- Query Port = 조회 전용 Port

## 💭 주의 사항

- 수강 신청이 실패하더라도 결제가 실패하면 안 된다고 생각하여 추후 이벤트 사용하여 비동기적으로 처리할 예정입니다.

## 💡 리뷰 포인트

- 전반적으로 봐주세용

## ✅ 테스트
- [x] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [x] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)

### API 테스트
- 결제 준비 API
<img width="816" height="302" alt="image" src="https://github.com/user-attachments/assets/d01a834f-7176-4452-8056-058502604943" />

- 결제 완료 API 
<img width="713" height="271" alt="image" src="https://github.com/user-attachments/assets/3186eb34-e8d3-4f37-ad31-c82b77b1d869" />

### DB 데이터 확인

- order_lines (item_id = course.id 입니다.
<img width="808" height="359" alt="image" src="https://github.com/user-attachments/assets/bc605364-d112-4388-af38-297fa21a0f01" />

- enrollments
<img width="1228" height="363" alt="image" src="https://github.com/user-attachments/assets/2b250d39-212f-408e-a9af-d6396e565350" />
