### PR TITLE
[FIX] 강의 API 인가 처리 보완

### DIFF
--- a/src/main/java/com/lxp/aplus/course/infrastructure/file/LectureFileValidator.java
+++ b/src/main/java/com/lxp/aplus/course/infrastructure/file/LectureFileValidator.java
@@ -4,7 +4,6 @@ import com.lxp.aplus.common.error.BusinessException;
 import com.lxp.aplus.common.error.code.LectureResourceErrorCode;
 import com.lxp.aplus.course.application.file.FileValidator;
 import com.lxp.aplus.course.application.vo.UploadFile;
-import com.lxp.aplus.course.domain.ExtensionType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -23,8 +22,6 @@ public class LectureFileValidator implements FileValidator {
         if (file.size() > MAX_FILE_SIZE) {
             throw new BusinessException(LectureResourceErrorCode.LECTURE_RESOURCE_FILE_SIZE_EXCEEDED);
         }
-
-        ExtensionType ext = ExtensionType.fromFileName(file.originalFileName());
     }
 
     @Override
@@ -35,7 +32,5 @@ public class LectureFileValidator implements FileValidator {
         if (file.size() > MAX_FILE_SIZE) {
             throw new BusinessException(LectureResourceErrorCode.LECTURE_RESOURCE_FILE_SIZE_EXCEEDED);
         }
-
-        ExtensionType ext = ExtensionType.fromFileName(file.originalFileName());
     }
 }

--- a/src/main/java/com/lxp/aplus/course/presentation/controller/LectureController.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/controller/LectureController.java
@@ -2,6 +2,7 @@ package com.lxp.aplus.course.presentation.controller;
 
 import com.lxp.aplus.common.result.ResultResponse;
 import com.lxp.aplus.common.result.code.LectureResultCode;
+import com.lxp.aplus.common.security.Authenticated;
 import com.lxp.aplus.common.security.InstructorOnly;
 import com.lxp.aplus.course.application.command.CreateLectureCommand;
 import com.lxp.aplus.course.application.command.UpdateLectureCommand;
@@ -35,6 +36,7 @@ public class LectureController {
             value = "/instructor/courses/{courseId}/sections/{sectionId}/lectures",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ResultResponse<LectureResponse>> createLecture (@Valid @PathVariable Long courseId,
+                                                                          @Authenticated Long instructorId,
                                                                           @PathVariable Long sectionId,
                                                                           @RequestPart("lecture") LectureCreateRequest request,
                                                                           @RequestPart("multiFile") MultipartFile file) throws IOException {
@@ -56,7 +58,9 @@ public class LectureController {
     /** 강의 상세 조회 **/
     @InstructorOnly
     @GetMapping("/instructor/courses/{courseId}/lectures/{lectureId}")
-    public ResponseEntity<ResultResponse<LectureResponse>> getLectureDetail(@PathVariable Long courseId, @PathVariable Long lectureId) {
+    public ResponseEntity<ResultResponse<LectureResponse>> getLectureDetail(@PathVariable Long courseId,
+                                                                            @Authenticated Long instructorId,
+                                                                            @PathVariable Long lectureId) {
         LectureResult result = lectureQueryUseCase.getLectureDetails(courseId, lectureId);
 
         return ResponseEntity
@@ -71,7 +75,9 @@ public class LectureController {
     @PutMapping(
             value = "/instructor/courses/{courseId}/lectures/{lectureId}",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ResultResponse<LectureResponse>> updateLecture(@Valid @PathVariable Long courseId, @PathVariable Long lectureId,
+    public ResponseEntity<ResultResponse<LectureResponse>> updateLecture(@Valid @PathVariable Long courseId,
+                                                                         @Authenticated Long instructorId,
+                                                                         @PathVariable Long lectureId,
                                                                          @RequestPart("lecture") LectureUpdateRequest request,
                                                                          @RequestPart(value = "multiFile", required = false) MultipartFile file) throws IOException{
 
@@ -95,7 +101,9 @@ public class LectureController {
     /** 강의 삭제 **/
     @InstructorOnly
     @DeleteMapping("/instructor/courses/{courseId}/lectures/{lectureId}")
-    public ResponseEntity<ResultResponse<Void>> deleteLecture(@PathVariable Long courseId, @PathVariable Long lectureId) {
+    public ResponseEntity<ResultResponse<Void>> deleteLecture(@PathVariable Long courseId,
+                                                              @Authenticated Long instructorId,
+                                                              @PathVariable Long lectureId) {
         lectureCommandUseCase.deleteLecture(courseId, lectureId);
 
         return ResponseEntity

--- a/src/test/http/lecture-api.http
+++ b/src/test/http/lecture-api.http
@@ -1,7 +1,7 @@
 @host = http://localhost:8000
 @courseId = 1
 @sectionId = 1
-@lectureId = 5
+@lectureId = 10
 
 ### 로그인해서 토큰 받기
 POST {{host}}/api/auth/login


### PR DESCRIPTION
## ✨ 요약
강의 관련 API에서 인가 처리 누락으로 인해 발생하던 인증 문제를 해결하고,
파일 업로드 로직 내 불필요한 확장자 처리 코드를 함께 정리했습니다.

`@InstructorOnly`가 적용된 엔드포인트에서 요청자 정보가 명시적으로 전달되지 않아
인가 로직이 정상적으로 동작하지 않던 부분을 보완하여,
강의 생성/수정/삭제 흐름의 안정성을 개선했습니다.

---

## 📝 작업 내용
- `@InstructorOnly`가 적용된 강의 API에 `@Authenticated instructorId` 파라미터 추가
- 요청자 정보 누락으로 발생하던 인증/인가 실패 및 WARN 로그 제거
- 강의 관련 UseCase에서 요청자(instructorId) 기반 인가 흐름 정상화
- 파일 업로드 로직에서 사용되지 않던  
  `ExtensionType.fromFileName(...)` 호출 제거
- 불필요한 파일 확장자 처리 코드 정리로 로직 단순화

---

## 💭 주의 사항
- `@InstructorOnly`가 적용된 컨트롤러 메서드에는
  반드시 `@Authenticated` 파라미터가 포함되어야 합니다.
- 해당 파라미터 누락 시, 인증이 완료되어도 인가 단계에서 문제가 발생할 수 있습니다.
- 파일 확장자 검증 로직은 현재 사용 중인 Validator 기준으로만 수행됩니다.

---

## 💡 리뷰 포인트
- `@InstructorOnly + @Authenticated` 조합이 강의 API 전반에 일관되게 적용되었는지
- 요청자 정보 전달 방식이 UseCase 및 도메인 인가 책임 분리에 적절한지
- 제거된 확장자 처리 로직이 다른 흐름에 영향을 주지 않는지
- 강의 생성/수정/삭제 HTTP 테스트에서 인증/인가가 정상 동작하는지

## ✅ 테스트
- [x] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [x] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
