### PR TITLE
[REFACTOR] Course/Section/Category 응답 객체 분리 및 계층 의존성 개선

### DIFF
--- a/src/main/java/com/lxp/aplus/category/application/result/CategoryResult.java
+++ b/src/main/java/com/lxp/aplus/category/application/result/CategoryResult.java
@@ -1,0 +1,21 @@
+package com.lxp.aplus.category.application.result;
+
+import com.lxp.aplus.category.domain.Category;
+
+import java.util.List;
+
+public record CategoryResult(
+        Long categoryId,
+        String name,
+        List<CategoryResult> children
+) {
+    public static CategoryResult from(Category category) {
+        return new CategoryResult(
+                category.getId(),
+                category.getName(),
+                category.getChildren().stream()
+                        .map(CategoryResult::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/lxp/aplus/category/application/usecase/CategoryQueryUseCase.java
+++ b/src/main/java/com/lxp/aplus/category/application/usecase/CategoryQueryUseCase.java
@@ -1,8 +1,8 @@
 package com.lxp.aplus.category.application.usecase;
 
+import com.lxp.aplus.category.application.result.CategoryResult;
 import com.lxp.aplus.category.domain.Category;
 import com.lxp.aplus.category.domain.CategoryRepository;
-import com.lxp.aplus.category.presentation.response.CategoryResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,8 +15,10 @@ import java.util.List;
 public class CategoryQueryUseCase {
     private final CategoryRepository categoryRepository;
 
-    public List<CategoryResponse> getAllCategories() {
-        List<Category> categoryResults = categoryRepository.findAllRootWithChildren();
-        return CategoryResponse.from(categoryResults);
+    public List<CategoryResult> getAllCategories() {
+        List<Category> categories = categoryRepository.findAllRootWithChildren();
+        return categories.stream()
+                .map(CategoryResult::from)
+                .toList();
     }
 }

--- a/src/main/java/com/lxp/aplus/category/presentation/controller/CategoryController.java
+++ b/src/main/java/com/lxp/aplus/category/presentation/controller/CategoryController.java
@@ -1,5 +1,6 @@
 package com.lxp.aplus.category.presentation.controller;
 
+import com.lxp.aplus.category.application.result.CategoryResult;
 import com.lxp.aplus.category.application.usecase.CategoryQueryUseCase;
 import com.lxp.aplus.category.presentation.response.CategoryResponse;
 import com.lxp.aplus.common.result.ResultResponse;
@@ -20,13 +21,10 @@ public class CategoryController {
 
     @GetMapping
     public ResponseEntity<ResultResponse<List<CategoryResponse>>> getAllCategories() {
-        List<CategoryResponse> categoryResults = categoryQueryUseCase.getAllCategories();
+        List<CategoryResult> results = categoryQueryUseCase.getAllCategories();
 
         return ResponseEntity
                 .status(CategoryResultCode.CATEGORY_LIST_SUCCESS.getStatus())
-                .body(ResultResponse.of(
-                        CategoryResultCode.CATEGORY_LIST_SUCCESS,
-                        categoryResults)
-                );
+                .body(ResultResponse.of(CategoryResultCode.CATEGORY_LIST_SUCCESS, CategoryResponse.from(results)));
     }
 }

--- a/src/main/java/com/lxp/aplus/category/presentation/response/CategoryResponse.java
+++ b/src/main/java/com/lxp/aplus/category/presentation/response/CategoryResponse.java
@@ -1,12 +1,10 @@
 package com.lxp.aplus.category.presentation.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.lxp.aplus.category.domain.Category;
+import com.lxp.aplus.category.application.result.CategoryResult;
 import lombok.Builder;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Builder
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -15,20 +13,19 @@ public record CategoryResponse(
         String name,
         List<CategoryResponse> children
 ) {
-    public static CategoryResponse from(Category category) {
+    public static CategoryResponse from(CategoryResult result) {
         return CategoryResponse.builder()
-                .categoryId(category.getId())
-                .name(category.getName())
-                .children(category.getChildren().stream()
-                                .map(CategoryResponse::from)
-                                .collect(Collectors.toList())
-                )
+                .categoryId(result.categoryId())
+                .name(result.name())
+                .children(result.children().stream()
+                        .map(CategoryResponse::from)
+                        .toList())
                 .build();
     }
 
-    public static List<CategoryResponse> from(List<Category> categories) {
-        return categories.stream()
+    public static List<CategoryResponse> from(List<CategoryResult> results) {
+        return results.stream()
                 .map(CategoryResponse::from)
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/src/main/java/com/lxp/aplus/course/application/port/out/UserQueryPort.java
+++ b/src/main/java/com/lxp/aplus/course/application/port/out/UserQueryPort.java
@@ -1,9 +1,9 @@
 package com.lxp.aplus.course.application.port.out;
 
-import com.lxp.aplus.course.presentation.response.InstructorResponse;
+import com.lxp.aplus.course.application.result.InstructorResult;
 
 import java.util.Optional;
 
 public interface UserQueryPort {
-    Optional<InstructorResponse> findInstructorById(Long userId);
+    Optional<InstructorResult> findInstructorById(Long userId);
 }

--- a/src/main/java/com/lxp/aplus/course/application/result/CourseDetailResult.java
+++ b/src/main/java/com/lxp/aplus/course/application/result/CourseDetailResult.java
@@ -1,0 +1,48 @@
+package com.lxp.aplus.course.application.result;
+
+import com.lxp.aplus.course.domain.Course;
+import com.lxp.aplus.course.domain.CourseLevel;
+import com.lxp.aplus.course.domain.CourseStatus;
+import lombok.Builder;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+public record CourseDetailResult(
+        Long courseId,
+        List<String> categories,
+        String title,
+        String summary,
+        String description,
+        int price,
+        CourseStatus status,
+        CourseLevel level,
+        String thumbnailUrl,
+        InstructorResult instructor,
+        boolean isPurchased,
+        int studentCount,
+        int totalDuration,
+        List<SectionResult> sections
+) {
+    public static CourseDetailResult of(Course course, List<String> categoryNames, InstructorResult instructor, boolean isPurchased, int studentCount, int totalDuration) {
+        return CourseDetailResult.builder()
+                .courseId(course.getId())
+                .categories(categoryNames)
+                .title(course.getTitle())
+                .summary(course.getSummary())
+                .description(course.getDescription())
+                .price(course.getPrice())
+                .status(course.getCourseStatus())
+                .level(course.getCourseLevel())
+                .thumbnailUrl(course.getThumbnailUrl())
+                .instructor(instructor)
+                .isPurchased(isPurchased)
+                .studentCount(studentCount)
+                .totalDuration(totalDuration)
+                .sections(course.getSections().stream()
+                        .map(SectionResult::from)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/src/main/java/com/lxp/aplus/course/application/result/CoursePublishResult.java
+++ b/src/main/java/com/lxp/aplus/course/application/result/CoursePublishResult.java
@@ -1,0 +1,20 @@
+package com.lxp.aplus.course.application.result;
+
+import com.lxp.aplus.course.domain.Course;
+import com.lxp.aplus.course.domain.CourseStatus;
+import lombok.Builder;
+
+@Builder
+public record CoursePublishResult(
+        Long id,
+        String title,
+        CourseStatus courseState
+) {
+    public static CoursePublishResult from(Course course) {
+        return CoursePublishResult.builder()
+                .id(course.getId())
+                .title(course.getTitle())
+                .courseState(course.getCourseStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/lxp/aplus/course/application/result/CourseResult.java
+++ b/src/main/java/com/lxp/aplus/course/application/result/CourseResult.java
@@ -1,0 +1,42 @@
+package com.lxp.aplus.course.application.result;
+
+import com.lxp.aplus.course.domain.Course;
+import com.lxp.aplus.course.domain.CourseLevel;
+import com.lxp.aplus.course.domain.CourseStatus;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record CourseResult(
+        Long courseId,
+        String title,
+        String summary,
+        String instructorName,
+        List<String> categories,
+        String thumbnailUrl,
+        CourseStatus status,
+        int price,
+        CourseLevel level,
+        int studentCount,
+        double rating,
+        LocalDateTime lastModifiedAt
+) {
+    public static CourseResult of(Course course, List<String> categoryNames, String instructorName, int studentCount) {
+        return CourseResult.builder()
+                .courseId(course.getId())
+                .title(course.getTitle())
+                .summary(course.getSummary())
+                .instructorName(instructorName)
+                .categories(categoryNames)
+                .thumbnailUrl(course.getThumbnailUrl())
+                .status(course.getCourseStatus())
+                .price(course.getPrice())
+                .level(course.getCourseLevel())
+                .studentCount(studentCount)
+                .rating(5.0)
+                .lastModifiedAt(course.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/lxp/aplus/course/application/result/CourseUpsertResult.java
+++ b/src/main/java/com/lxp/aplus/course/application/result/CourseUpsertResult.java
@@ -1,0 +1,15 @@
+package com.lxp.aplus.course.application.result;
+
+import com.lxp.aplus.course.domain.Course;
+import lombok.Builder;
+
+@Builder
+public record CourseUpsertResult(
+        Long courseId
+) {
+    public static CourseUpsertResult from(Course course) {
+        return CourseUpsertResult.builder()
+                .courseId(course.getId())
+                .build();
+    }
+}

--- a/src/main/java/com/lxp/aplus/course/application/result/InstructorResult.java
+++ b/src/main/java/com/lxp/aplus/course/application/result/InstructorResult.java
@@ -1,0 +1,17 @@
+package com.lxp.aplus.course.application.result;
+
+import com.lxp.aplus.user.domain.User;
+import lombok.Builder;
+
+@Builder
+public record InstructorResult(
+        Long id,
+        String name
+) {
+    public static InstructorResult from(User user) {
+        return InstructorResult.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/lxp/aplus/course/application/result/SectionResult.java
+++ b/src/main/java/com/lxp/aplus/course/application/result/SectionResult.java
@@ -1,0 +1,26 @@
+package com.lxp.aplus.course.application.result;
+
+import com.lxp.aplus.course.domain.Section;
+import lombok.Builder;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+public record SectionResult(
+        Long sectionId,
+        String title,
+        int order,
+        List<LectureResult> lectures
+) {
+    public static SectionResult from(Section section) {
+        return SectionResult.builder()
+                .sectionId(section.getId())
+                .title(section.getTitle())
+                .order(section.getOrderIndex())
+                .lectures(section.getLectures().stream()
+                        .map(LectureResult::from)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/src/main/java/com/lxp/aplus/course/application/result/SectionUpsertResult.java
+++ b/src/main/java/com/lxp/aplus/course/application/result/SectionUpsertResult.java
@@ -1,0 +1,19 @@
+package com.lxp.aplus.course.application.result;
+
+import com.lxp.aplus.course.domain.Section;
+import lombok.Builder;
+
+@Builder
+public record SectionUpsertResult(
+        Long sectionId,
+        String title,
+        int orderIndex
+) {
+    public static SectionUpsertResult from(Section section) {
+        return SectionUpsertResult.builder()
+                .sectionId(section.getId())
+                .title(section.getTitle())
+                .orderIndex(section.getOrderIndex())
+                .build();
+    }
+}

--- a/src/main/java/com/lxp/aplus/course/application/usecase/CourseCommandUseCase.java
+++ b/src/main/java/com/lxp/aplus/course/application/usecase/CourseCommandUseCase.java
@@ -2,18 +2,13 @@ package com.lxp.aplus.course.application.usecase;
 
 import com.lxp.aplus.common.error.BusinessException;
 import com.lxp.aplus.common.error.code.CourseErrorCode;
-import com.lxp.aplus.common.error.code.SectionErrorCode;
 import com.lxp.aplus.common.file.FileUploader;
 import com.lxp.aplus.course.application.command.CourseCreateCommand;
 import com.lxp.aplus.course.application.command.CourseUpdateCommand;
-import com.lxp.aplus.course.application.command.SectionCreateCommand;
-import com.lxp.aplus.course.application.command.SectionUpdateCommand;
+import com.lxp.aplus.course.application.result.CoursePublishResult;
+import com.lxp.aplus.course.application.result.CourseUpsertResult;
 import com.lxp.aplus.course.domain.Course;
 import com.lxp.aplus.course.domain.CourseRepository;
-import com.lxp.aplus.course.domain.Section;
-import com.lxp.aplus.course.presentation.response.CoursePublishResponse;
-import com.lxp.aplus.course.presentation.response.CourseUpsertResponse;
-import com.lxp.aplus.course.presentation.response.SectionUpsertResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,22 +20,22 @@ public class CourseCommandUseCase {
     private final CourseRepository courseRepository;
     private final FileUploader fileUploader;
 
-    public CourseUpsertResponse createCourse(Long instructorId, CourseCreateCommand command) {
+    public CourseUpsertResult createCourse(Long instructorId, CourseCreateCommand command) {
         String thumbnailUrl = fileUploader.upload(command.thumbnailFile());
         Course course = Course.createDraftCourse(instructorId, thumbnailUrl, command);
         Course savedCourse = courseRepository.save(course);
 
-        return CourseUpsertResponse.from(savedCourse);
+        return CourseUpsertResult.from(savedCourse);
     }
 
-    public CourseUpsertResponse updateCourse(Long courseId, Long instructorId, CourseUpdateCommand command) {
+    public CourseUpsertResult updateCourse(Long courseId, Long instructorId, CourseUpdateCommand command) {
         Course course = courseRepository.findById(courseId)
                 .orElseThrow(() -> new BusinessException(CourseErrorCode.COURSE_NOT_FOUND));
 
         course.validateOwner(instructorId);
         course.updateCourse(command);
 
-        return CourseUpsertResponse.from(course);
+        return CourseUpsertResult.from(course);
     }
 
     public void deleteCourse(Long courseId, Long instructorId) {
@@ -51,49 +46,13 @@ public class CourseCommandUseCase {
         course.deleteCourse();
     }
 
-    public SectionUpsertResponse createSection(Long courseId, Long instructorId, SectionCreateCommand command) {
-        Course course = courseRepository.findById(courseId)
-                .orElseThrow(() -> new BusinessException(CourseErrorCode.COURSE_NOT_FOUND));
-
-        course.validateOwner(instructorId);
-        course.addSection(command.title(), command.orderIndex());
-        Course savedCourse = courseRepository.save(course);
-        courseRepository.flush();
-
-        Section newSection = savedCourse.getSections().stream()
-                .filter(section -> section.getOrderIndex() == command.orderIndex()
-                        && section.getTitle().equals(command.title()))
-                .findFirst()
-                .orElseThrow(() -> new BusinessException(SectionErrorCode.SECTION_NOT_FOUND));
-
-        return SectionUpsertResponse.from(newSection);
-    }
-
-    public SectionUpsertResponse updateSection(Long courseId, Long instructorId, Long sectionId, SectionUpdateCommand command) {
-        Course course = courseRepository.findById(courseId)
-                .orElseThrow(() -> new BusinessException(CourseErrorCode.COURSE_NOT_FOUND));
-
-        course.validateOwner(instructorId);
-        Section updatedSection = course.updateSection(sectionId, command.title(), command.orderIndex());
-
-        return SectionUpsertResponse.from(updatedSection);
-    }
-
-    public void deleteSection(Long courseId, Long instructorId, Long sectionId) {
-        Course course = courseRepository.findById(courseId)
-                .orElseThrow(() -> new BusinessException(CourseErrorCode.COURSE_NOT_FOUND));
-
-        course.validateOwner(instructorId);
-        course.deleteSection(sectionId);
-    }
-
-    public CoursePublishResponse publishCourse(Long courseId, Long instructorId) {
+    public CoursePublishResult publishCourse(Long courseId, Long instructorId) {
         Course course = courseRepository.findById(courseId)
                 .orElseThrow(() -> new BusinessException(CourseErrorCode.COURSE_NOT_FOUND));
 
         course.validateOwner(instructorId);
         course.publish();
 
-        return CoursePublishResponse.from(course);
+        return CoursePublishResult.from(course);
     }
 }

--- a/src/main/java/com/lxp/aplus/course/application/usecase/CourseQueryUseCase.java
+++ b/src/main/java/com/lxp/aplus/course/application/usecase/CourseQueryUseCase.java
@@ -6,11 +6,11 @@ import com.lxp.aplus.common.error.code.UserErrorCode;
 import com.lxp.aplus.course.application.port.out.CategoryQueryPort;
 import com.lxp.aplus.course.application.port.out.EnrollmentQueryPort;
 import com.lxp.aplus.course.application.port.out.UserQueryPort;
+import com.lxp.aplus.course.application.result.CourseDetailResult;
+import com.lxp.aplus.course.application.result.CourseResult;
+import com.lxp.aplus.course.application.result.InstructorResult;
 import com.lxp.aplus.course.domain.Course;
 import com.lxp.aplus.course.domain.CourseRepository;
-import com.lxp.aplus.course.presentation.response.CourseDetailResponse;
-import com.lxp.aplus.course.presentation.response.CourseResponse;
-import com.lxp.aplus.course.presentation.response.InstructorResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -31,17 +31,17 @@ public class CourseQueryUseCase {
     private final CategoryQueryPort categoryQueryPort;
     private final EnrollmentQueryPort enrollmentQueryPort;
 
-    public Page<CourseResponse> getInstructorCourses(Long instructorId, Pageable pageable) {
+    public Page<CourseResult> getInstructorCourses(Long instructorId, Pageable pageable) {
         Page<Course> courses = courseRepository.findAllByInstructorIdExcludingDeleted(instructorId, pageable);
         return convertToCourseResponse(courses, pageable);
     }
 
-    public Page<CourseResponse> getPublishedCourses(Pageable pageable) {
+    public Page<CourseResult> getPublishedCourses(Pageable pageable) {
         Page<Course> courses = courseRepository.findAllPublished(pageable);
         return convertToCourseResponse(courses, pageable);
     }
 
-    private Page<CourseResponse> convertToCourseResponse(Page<Course> courses, Pageable pageable) {
+    private Page<CourseResult> convertToCourseResponse(Page<Course> courses, Pageable pageable) {
         List<Long> categoryIds = courses.getContent().stream()
                 .map(Course::getCategoryId)
                 .distinct()
@@ -54,13 +54,13 @@ public class CourseQueryUseCase {
         Map<Long, List<String>> categoryNamesMap = categoryQueryPort.getCategoryNamesBatch(categoryIds);
         Map<Long, Integer> studentCountMap = enrollmentQueryPort.getStudentCountBatch(courseIds);
 
-        List<CourseResponse> courseResponses = courses.getContent().stream()
+        List<CourseResult> courseResponses = courses.getContent().stream()
                 .map(course -> {
                     String instructorName = userQueryPort.findInstructorById(course.getInstructorId())
-                            .map(InstructorResponse::name)
+                            .map(InstructorResult::name)
                             .orElse("알 수 없음");
 
-                    return CourseResponse.of(
+                    return CourseResult.of(
                             course,
                             categoryNamesMap.get(course.getCategoryId()),
                             instructorName,
@@ -79,13 +79,13 @@ public class CourseQueryUseCase {
         return categoryQueryPort.findCategoryWithParentNames(categoryId);
     }
 
-    public CourseDetailResponse getPublishedCourseDetail(Long courseId, Long userId) {
+    public CourseDetailResult getPublishedCourseDetail(Long courseId, Long userId) {
         Course course = courseRepository.findPublishedWithCurriculumById(courseId)
                 .orElseThrow(() -> new BusinessException(CourseErrorCode.COURSE_NOT_FOUND));
 
         List<String> categoryNames = getCategoryNames(course.getCategoryId());
 
-        InstructorResponse instructorResponse = userQueryPort.findInstructorById(course.getInstructorId())
+        InstructorResult instructorResult = userQueryPort.findInstructorById(course.getInstructorId())
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
         int totalDuration = calculateTotalDuration(course);
@@ -93,10 +93,10 @@ public class CourseQueryUseCase {
         boolean isPurchased = enrollmentQueryPort.isEnrolled(userId, courseId);
         int studentCount = enrollmentQueryPort.getStudentCount(courseId);
 
-        return CourseDetailResponse.of(course, categoryNames, instructorResponse, isPurchased, studentCount, totalDuration);
+        return CourseDetailResult.of(course, categoryNames, instructorResult, isPurchased, studentCount, totalDuration);
     }
 
-    public CourseDetailResponse getInstructorCourseDetail(Long courseId, Long instructorId) {
+    public CourseDetailResult getInstructorCourseDetail(Long courseId, Long instructorId) {
         Course course = courseRepository.findWithCurriculumById(courseId)
                 .orElseThrow(() -> new BusinessException(CourseErrorCode.COURSE_NOT_FOUND));
 
@@ -104,7 +104,7 @@ public class CourseQueryUseCase {
 
         List<String> categoryNames = getCategoryNames(course.getCategoryId());
 
-        InstructorResponse instructorResponse = userQueryPort.findInstructorById(course.getInstructorId())
+        InstructorResult instructorResult = userQueryPort.findInstructorById(course.getInstructorId())
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
         int totalDuration = calculateTotalDuration(course);
@@ -112,7 +112,7 @@ public class CourseQueryUseCase {
         boolean isPurchased = enrollmentQueryPort.isEnrolled(instructorId, courseId);
         int studentCount = enrollmentQueryPort.getStudentCount(courseId);
 
-        return CourseDetailResponse.of(course, categoryNames, instructorResponse, isPurchased, studentCount, totalDuration);
+        return CourseDetailResult.of(course, categoryNames, instructorResult, isPurchased, studentCount, totalDuration);
     }
 
     private int calculateTotalDuration(Course course) {

--- a/src/main/java/com/lxp/aplus/course/application/usecase/SectionCommandUseCase.java
+++ b/src/main/java/com/lxp/aplus/course/application/usecase/SectionCommandUseCase.java
@@ -1,0 +1,57 @@
+package com.lxp.aplus.course.application.usecase;
+
+import com.lxp.aplus.common.error.BusinessException;
+import com.lxp.aplus.common.error.code.CourseErrorCode;
+import com.lxp.aplus.common.error.code.SectionErrorCode;
+import com.lxp.aplus.course.application.command.SectionCreateCommand;
+import com.lxp.aplus.course.application.command.SectionUpdateCommand;
+import com.lxp.aplus.course.application.result.SectionUpsertResult;
+import com.lxp.aplus.course.domain.Course;
+import com.lxp.aplus.course.domain.CourseRepository;
+import com.lxp.aplus.course.domain.Section;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SectionCommandUseCase {
+    private final CourseRepository courseRepository;
+
+    public SectionUpsertResult createSection(Long courseId, Long instructorId, SectionCreateCommand command) {
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new BusinessException(CourseErrorCode.COURSE_NOT_FOUND));
+
+        course.validateOwner(instructorId);
+        course.addSection(command.title(), command.orderIndex());
+        Course savedCourse = courseRepository.save(course);
+        courseRepository.flush();
+
+        Section newSection = savedCourse.getSections().stream()
+                .filter(section -> section.getOrderIndex() == command.orderIndex()
+                        && section.getTitle().equals(command.title()))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(SectionErrorCode.SECTION_NOT_FOUND));
+
+        return SectionUpsertResult.from(newSection);
+    }
+
+    public SectionUpsertResult updateSection(Long courseId, Long instructorId, Long sectionId, SectionUpdateCommand command) {
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new BusinessException(CourseErrorCode.COURSE_NOT_FOUND));
+
+        course.validateOwner(instructorId);
+        Section updatedSection = course.updateSection(sectionId, command.title(), command.orderIndex());
+
+        return SectionUpsertResult.from(updatedSection);
+    }
+
+    public void deleteSection(Long courseId, Long instructorId, Long sectionId) {
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new BusinessException(CourseErrorCode.COURSE_NOT_FOUND));
+
+        course.validateOwner(instructorId);
+        course.deleteSection(sectionId);
+    }
+}

--- a/src/main/java/com/lxp/aplus/course/infrastructure/adapter/UserQueryAdapter.java
+++ b/src/main/java/com/lxp/aplus/course/infrastructure/adapter/UserQueryAdapter.java
@@ -1,6 +1,7 @@
 package com.lxp.aplus.course.infrastructure.adapter;
 
 import com.lxp.aplus.course.application.port.out.UserQueryPort;
+import com.lxp.aplus.course.application.result.InstructorResult;
 import com.lxp.aplus.course.presentation.response.InstructorResponse;
 import com.lxp.aplus.user.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,8 +15,8 @@ public class UserQueryAdapter implements UserQueryPort {
     private final UserRepository userRepository;
 
     @Override
-    public Optional<InstructorResponse> findInstructorById(Long userId) {
+    public Optional<InstructorResult> findInstructorById(Long userId) {
         return userRepository.findById(userId)
-                .map(InstructorResponse::from);
+                .map(InstructorResult::from);
     }
 }

--- a/src/main/java/com/lxp/aplus/course/infrastructure/persistence/CourseJpaRepository.java
+++ b/src/main/java/com/lxp/aplus/course/infrastructure/persistence/CourseJpaRepository.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface CourseJpaRepository extends JpaRepository<Course, Long> {
+    Optional<Course> findByIdAndCourseStatusNot(Long id, CourseStatus courseStatus);
+
     Page<Course> findAllByInstructorIdAndCourseStatusNot(Long instructorId, CourseStatus courseStatus, Pageable pageable);
 
     Page<Course> findAllByCourseStatus(CourseStatus courseStatus, Pageable pageable);

--- a/src/main/java/com/lxp/aplus/course/infrastructure/persistence/CourseRepositoryImpl.java
+++ b/src/main/java/com/lxp/aplus/course/infrastructure/persistence/CourseRepositoryImpl.java
@@ -29,7 +29,7 @@ public class CourseRepositoryImpl implements CourseRepository {
 
     @Override
     public Optional<Course> findById(Long id) {
-        return jpaRepository.findById(id);
+        return jpaRepository.findByIdAndCourseStatusNot(id, CourseStatus.DELETED);
     }
 
     @Override

--- a/src/main/java/com/lxp/aplus/course/presentation/controller/CourseController.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/controller/CourseController.java
@@ -7,6 +7,10 @@ import com.lxp.aplus.common.security.Authenticated;
 import com.lxp.aplus.common.security.CurrentUser;
 import com.lxp.aplus.common.security.InstructorOnly;
 import com.lxp.aplus.common.security.UserInfo;
+import com.lxp.aplus.course.application.result.CourseDetailResult;
+import com.lxp.aplus.course.application.result.CoursePublishResult;
+import com.lxp.aplus.course.application.result.CourseResult;
+import com.lxp.aplus.course.application.result.CourseUpsertResult;
 import com.lxp.aplus.course.application.usecase.CourseCommandUseCase;
 import com.lxp.aplus.course.application.usecase.CourseQueryUseCase;
 import com.lxp.aplus.course.presentation.request.CourseCreateRequest;
@@ -46,11 +50,11 @@ public class CourseController {
             @RequestPart("request") @Valid CourseCreateRequest request,
             @RequestPart("thumbnail") MultipartFile thumbnail
     ) {
-        CourseUpsertResponse courseUpsertResponse = courseCommandUseCase.createCourse(instructorId, request.toCommand(thumbnail));
+        CourseUpsertResult result = courseCommandUseCase.createCourse(instructorId, request.toCommand(thumbnail));
 
         return ResponseEntity
                 .status(CourseResultCode.COURSE_REGISTER_SUCCESS.getStatus())
-                .body(ResultResponse.of(CourseResultCode.COURSE_REGISTER_SUCCESS, courseUpsertResponse));
+                .body(ResultResponse.of(CourseResultCode.COURSE_REGISTER_SUCCESS, CourseUpsertResponse.from(result)));
     }
 
     @InstructorOnly
@@ -60,11 +64,11 @@ public class CourseController {
             @PathVariable("courseId") Long courseId,
             @RequestBody CourseUpdateRequest request
     ) {
-        CourseUpsertResponse courseUpsertResponse = courseCommandUseCase.updateCourse(courseId, instructorId, request.toCommand());
+        CourseUpsertResult result = courseCommandUseCase.updateCourse(courseId, instructorId, request.toCommand());
 
         return ResponseEntity
                 .status(CourseResultCode.COURSE_UPDATE_SUCCESS.getStatus())
-                .body(ResultResponse.of(CourseResultCode.COURSE_UPDATE_SUCCESS, courseUpsertResponse));
+                .body(ResultResponse.of(CourseResultCode.COURSE_UPDATE_SUCCESS, CourseUpsertResponse.from(result)));
     }
 
     @InstructorOnly
@@ -73,11 +77,11 @@ public class CourseController {
             @Authenticated Long instructorId,
             @PathVariable("courseId") Long courseId
     ) {
-        CourseDetailResponse courseDetailResponse = courseQueryUseCase.getInstructorCourseDetail(courseId, instructorId);
+        CourseDetailResult result = courseQueryUseCase.getInstructorCourseDetail(courseId, instructorId);
 
         return ResponseEntity
                 .status(CourseResultCode.COURSE_READ_SUCCESS.getStatus())
-                .body(ResultResponse.of(CourseResultCode.COURSE_READ_SUCCESS, courseDetailResponse));
+                .body(ResultResponse.of(CourseResultCode.COURSE_READ_SUCCESS, CourseDetailResponse.from(result)));
     }
 
     @GetMapping("/api/courses/{courseId}")
@@ -85,11 +89,11 @@ public class CourseController {
             @CurrentUser UserInfo userInfo,
             @PathVariable("courseId") Long courseId
     ) {
-        CourseDetailResponse courseDetailResponse = courseQueryUseCase.getPublishedCourseDetail(courseId, userInfo.id());
+        CourseDetailResult result = courseQueryUseCase.getPublishedCourseDetail(courseId, userInfo.id());
 
         return ResponseEntity
                 .status(CourseResultCode.COURSE_READ_SUCCESS.getStatus())
-                .body(ResultResponse.of(CourseResultCode.COURSE_READ_SUCCESS, courseDetailResponse));
+                .body(ResultResponse.of(CourseResultCode.COURSE_READ_SUCCESS, CourseDetailResponse.from(result)));
     }
 
     @InstructorOnly
@@ -98,22 +102,24 @@ public class CourseController {
             @Authenticated Long instructorId,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        Page<CourseResponse> result = courseQueryUseCase.getInstructorCourses(instructorId, pageable);
+        Page<CourseResult> result = courseQueryUseCase.getInstructorCourses(instructorId, pageable);
+        Page<CourseResponse> responsePage = result.map(CourseResponse::from);
 
         return ResponseEntity
                 .status(CourseResultCode.COURSE_LIST_SUCCESS.getStatus())
-                .body(ResultResponse.of(CourseResultCode.COURSE_LIST_SUCCESS, PageResponse.from(result)));
+                .body(ResultResponse.of(CourseResultCode.COURSE_LIST_SUCCESS, PageResponse.from(responsePage)));
     }
 
     @GetMapping("/api/courses")
     public ResponseEntity<ResultResponse<PageResponse<CourseResponse>>> getPublishedCourses(
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        Page<CourseResponse> result = courseQueryUseCase.getPublishedCourses(pageable);
+        Page<CourseResult> result = courseQueryUseCase.getPublishedCourses(pageable);
+        Page<CourseResponse> responsePage = result.map(CourseResponse::from);
 
         return ResponseEntity
                 .status(CourseResultCode.COURSE_LIST_SUCCESS.getStatus())
-                .body(ResultResponse.of(CourseResultCode.COURSE_LIST_SUCCESS, PageResponse.from(result)));
+                .body(ResultResponse.of(CourseResultCode.COURSE_LIST_SUCCESS, PageResponse.from(responsePage)));
     }
 
     @InstructorOnly
@@ -135,10 +141,10 @@ public class CourseController {
             @PathVariable Long courseId,
             @Authenticated Long instructorId
     ) {
-        CoursePublishResponse response = courseCommandUseCase.publishCourse(courseId, instructorId);
+        CoursePublishResult result = courseCommandUseCase.publishCourse(courseId, instructorId);
 
         return ResponseEntity
                 .status(CourseResultCode.COURSE_PUBLISH_SUCCESS.getStatus())
-                .body(ResultResponse.of(CourseResultCode.COURSE_PUBLISH_SUCCESS, response));
+                .body(ResultResponse.of(CourseResultCode.COURSE_PUBLISH_SUCCESS, CoursePublishResponse.from(result)));
     }
 }

--- a/src/main/java/com/lxp/aplus/course/presentation/controller/SectionController.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/controller/SectionController.java
@@ -4,8 +4,8 @@ import com.lxp.aplus.common.result.ResultResponse;
 import com.lxp.aplus.common.result.code.SectionResultCode;
 import com.lxp.aplus.common.security.Authenticated;
 import com.lxp.aplus.common.security.InstructorOnly;
-import com.lxp.aplus.course.application.usecase.CourseCommandUseCase;
-import com.lxp.aplus.course.application.usecase.CourseQueryUseCase;
+import com.lxp.aplus.course.application.result.SectionUpsertResult;
+import com.lxp.aplus.course.application.usecase.SectionCommandUseCase;
 import com.lxp.aplus.course.presentation.request.SectionCreateRequest;
 import com.lxp.aplus.course.presentation.request.SectionUpdateRequest;
 import com.lxp.aplus.course.presentation.response.SectionUpsertResponse;
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 public class SectionController {
-    private final CourseCommandUseCase courseCommandUseCase;
+    private final SectionCommandUseCase sectionCommandUseCase;
 
     @InstructorOnly
     @PostMapping("/api/instructor/courses/{courseId}/sections")
@@ -31,11 +31,11 @@ public class SectionController {
             @PathVariable("courseId") Long courseId,
             @Valid @RequestBody SectionCreateRequest request
     ) {
-        SectionUpsertResponse response = courseCommandUseCase.createSection(courseId, instructorId, request.toCommand());
+        SectionUpsertResult result = sectionCommandUseCase.createSection(courseId, instructorId, request.toCommand());
 
         return ResponseEntity
                 .status(SectionResultCode.SECTION_REGISTER_SUCCESS.getStatus())
-                .body(ResultResponse.of(SectionResultCode.SECTION_REGISTER_SUCCESS, response));
+                .body(ResultResponse.of(SectionResultCode.SECTION_REGISTER_SUCCESS, SectionUpsertResponse.from(result)));
     }
 
     @InstructorOnly
@@ -46,11 +46,11 @@ public class SectionController {
             @PathVariable("sectionId") Long sectionId,
             @RequestBody SectionUpdateRequest request
     ) {
-        SectionUpsertResponse response = courseCommandUseCase.updateSection(courseId, instructorId, sectionId, request.toCommand());
+        SectionUpsertResult result = sectionCommandUseCase.updateSection(courseId, instructorId, sectionId, request.toCommand());
 
         return ResponseEntity
                 .status(SectionResultCode.SECTION_UPDATE_SUCCESS.getStatus())
-                .body(ResultResponse.of(SectionResultCode.SECTION_UPDATE_SUCCESS, response));
+                .body(ResultResponse.of(SectionResultCode.SECTION_UPDATE_SUCCESS, SectionUpsertResponse.from(result)));
     }
 
     @InstructorOnly
@@ -60,7 +60,7 @@ public class SectionController {
             @PathVariable("courseId") Long courseId,
             @PathVariable("sectionId") Long sectionId
     ) {
-        courseCommandUseCase.deleteSection(courseId, instructorId, sectionId);
+        sectionCommandUseCase.deleteSection(courseId, instructorId, sectionId);
 
         return ResponseEntity
                 .status(SectionResultCode.SECTION_DELETE_SUCCESS.getStatus())

--- a/src/main/java/com/lxp/aplus/course/presentation/response/CourseDetailResponse.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/response/CourseDetailResponse.java
@@ -1,6 +1,6 @@
 package com.lxp.aplus.course.presentation.response;
 
-import com.lxp.aplus.course.domain.Course;
+import com.lxp.aplus.course.application.result.CourseDetailResult;
 import com.lxp.aplus.course.domain.CourseLevel;
 import com.lxp.aplus.course.domain.CourseStatus;
 import lombok.Builder;
@@ -25,22 +25,22 @@ public record CourseDetailResponse(
         int totalDuration,
         List<SectionResponse> sections
 ) {
-    public static CourseDetailResponse of(Course course, List<String> categoryNames, InstructorResponse instructor, boolean isPurchased, int studentCount, int totalDuration) {
+    public static CourseDetailResponse from(CourseDetailResult result) {
         return CourseDetailResponse.builder()
-                .courseId(course.getId())
-                .categories(categoryNames)
-                .title(course.getTitle())
-                .summary(course.getSummary())
-                .description(course.getDescription())
-                .price(course.getPrice())
-                .status(course.getCourseStatus())
-                .level(course.getCourseLevel())
-                .thumbnailUrl(course.getThumbnailUrl())
-                .instructor(instructor)
-                .isPurchased(isPurchased)
-                .studentCount(studentCount)
-                .totalDuration(totalDuration)
-                .sections(course.getSections().stream()
+                .courseId(result.courseId())
+                .categories(result.categories())
+                .title(result.title())
+                .summary(result.summary())
+                .description(result.description())
+                .price(result.price())
+                .status(result.status())
+                .level(result.level())
+                .thumbnailUrl(result.thumbnailUrl())
+                .instructor(InstructorResponse.from(result.instructor()))
+                .isPurchased(result.isPurchased())
+                .studentCount(result.studentCount())
+                .totalDuration(result.totalDuration())
+                .sections(result.sections().stream()
                         .map(SectionResponse::from)
                         .collect(Collectors.toList()))
                 .build();

--- a/src/main/java/com/lxp/aplus/course/presentation/response/CoursePublishResponse.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/response/CoursePublishResponse.java
@@ -1,6 +1,6 @@
 package com.lxp.aplus.course.presentation.response;
 
-import com.lxp.aplus.course.domain.Course;
+import com.lxp.aplus.course.application.result.CoursePublishResult;
 import com.lxp.aplus.course.domain.CourseStatus;
 import lombok.Builder;
 
@@ -10,11 +10,11 @@ public record CoursePublishResponse(
         String title,
         CourseStatus courseState
 ) {
-    public static CoursePublishResponse from(Course course) {
+    public static CoursePublishResponse from(CoursePublishResult result) {
         return CoursePublishResponse.builder()
-                .id(course.getId())
-                .title(course.getTitle())
-                .courseState(course.getCourseStatus())
+                .id(result.id())
+                .title(result.title())
+                .courseState(result.courseState())
                 .build();
     }
 }

--- a/src/main/java/com/lxp/aplus/course/presentation/response/CourseResponse.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/response/CourseResponse.java
@@ -1,6 +1,6 @@
 package com.lxp.aplus.course.presentation.response;
 
-import com.lxp.aplus.course.domain.Course;
+import com.lxp.aplus.course.application.result.CourseResult;
 import com.lxp.aplus.course.domain.CourseLevel;
 import com.lxp.aplus.course.domain.CourseStatus;
 import lombok.Builder;
@@ -23,20 +23,20 @@ public record CourseResponse(
         double rating,
         LocalDateTime lastModifiedAt
 ) {
-    public static CourseResponse of(Course course, List<String> categoryNames, String instructorName, int studentCount) {
+    public static CourseResponse from(CourseResult result) {
         return CourseResponse.builder()
-                .courseId(course.getId())
-                .title(course.getTitle())
-                .summary(course.getSummary())
-                .instructorName(instructorName)
-                .categories(categoryNames)
-                .thumbnailUrl(course.getThumbnailUrl())
-                .status(course.getCourseStatus())
-                .price(course.getPrice())
-                .level(course.getCourseLevel())
-                .studentCount(studentCount)
-                .rating(5.0)
-                .lastModifiedAt(course.getUpdatedAt())
+                .courseId(result.courseId())
+                .title(result.title())
+                .summary(result.summary())
+                .instructorName(result.instructorName())
+                .categories(result.categories())
+                .thumbnailUrl(result.thumbnailUrl())
+                .status(result.status())
+                .price(result.price())
+                .level(result.level())
+                .studentCount(result.studentCount())
+                .rating(result.rating())
+                .lastModifiedAt(result.lastModifiedAt())
                 .build();
     }
 }

--- a/src/main/java/com/lxp/aplus/course/presentation/response/CourseUpsertResponse.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/response/CourseUpsertResponse.java
@@ -1,15 +1,15 @@
 package com.lxp.aplus.course.presentation.response;
 
-import com.lxp.aplus.course.domain.Course;
+import com.lxp.aplus.course.application.result.CourseUpsertResult;
 import lombok.Builder;
 
 @Builder
 public record CourseUpsertResponse(
         Long courseId
 ) {
-    public static CourseUpsertResponse from(Course course) {
+    public static CourseUpsertResponse from(CourseUpsertResult result) {
         return CourseUpsertResponse.builder()
-                .courseId(course.getId())
+                .courseId(result.courseId())
                 .build();
     }
 }

--- a/src/main/java/com/lxp/aplus/course/presentation/response/InstructorResponse.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/response/InstructorResponse.java
@@ -1,5 +1,6 @@
 package com.lxp.aplus.course.presentation.response;
 
+import com.lxp.aplus.course.application.result.InstructorResult;
 import com.lxp.aplus.user.domain.User;
 import lombok.Builder;
 
@@ -8,10 +9,10 @@ public record InstructorResponse(
         Long id,
         String name
 ) {
-    public static InstructorResponse from(User user) {
+    public static InstructorResponse from(InstructorResult result) {
         return InstructorResponse.builder()
-                .id(user.getId())
-                .name(user.getName())
+                .id(result.id())
+                .name(result.name())
                 .build();
     }
 }

--- a/src/main/java/com/lxp/aplus/course/presentation/response/SectionResponse.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/response/SectionResponse.java
@@ -1,6 +1,6 @@
 package com.lxp.aplus.course.presentation.response;
 
-import com.lxp.aplus.course.domain.Section;
+import com.lxp.aplus.course.application.result.SectionResult;
 import lombok.Builder;
 
 import java.util.List;
@@ -13,12 +13,12 @@ public record SectionResponse(
         int order,
         List<LectureResponse> lectures
 ) {
-    public static SectionResponse from(Section section) {
+    public static SectionResponse from(SectionResult result) {
         return SectionResponse.builder()
-                .sectionId(section.getId())
-                .title(section.getTitle())
-                .order(section.getOrderIndex())
-                .lectures(section.getLectures().stream()
+                .sectionId(result.sectionId())
+                .title(result.title())
+                .order(result.order())
+                .lectures(result.lectures().stream()
                         .map(LectureResponse::from)
                         .collect(Collectors.toList()))
                 .build();

--- a/src/main/java/com/lxp/aplus/course/presentation/response/SectionUpsertResponse.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/response/SectionUpsertResponse.java
@@ -1,6 +1,6 @@
 package com.lxp.aplus.course.presentation.response;
 
-import com.lxp.aplus.course.domain.Section;
+import com.lxp.aplus.course.application.result.SectionUpsertResult;
 import lombok.Builder;
 
 @Builder
@@ -9,11 +9,11 @@ public record SectionUpsertResponse(
         String title,
         int orderIndex
 ) {
-    public static SectionUpsertResponse from(Section section) {
+    public static SectionUpsertResponse from(SectionUpsertResult result) {
         return SectionUpsertResponse.builder()
-                .sectionId(section.getId())
-                .title(section.getTitle())
-                .orderIndex(section.getOrderIndex())
+                .sectionId(result.sectionId())
+                .title(result.title())
+                .orderIndex(result.orderIndex())
                 .build();
     }
 }


### PR DESCRIPTION
## ✨ 요약
`Course`, `Section`, `Category` 도메인에서 Controller와 UseCase가 동일한 응답 객체(`Response`)를 사용하는 문제를 해결하기 위해, Application Layer 전용 `Result` 객체를 도입하고 계층 간 의존성을 분리했습니다.

## 📝 작업 내용
-  **DTO 분리**
   - `application/result` 패키지에 `CourseResult`, SectionResult`, CategoryResult` 등 비즈니스 결과 객체 추가
   - `presentation/response` 패키지의 객체들은 오직 표현 계층에서만 사용되도록 수정
   - 각 `Response` 클래스 내부에 `from(Result result)` 메서드를 구현하여 변환 로직 캡슐화 (Builder 패턴 사용)

## 💭 주의 사항
- 기존 API 응답 스펙(JSON 필드명 등)은 변경되지 않았습니다. 내부 구조만 변경되었습니다.
- `InstructorResponse`는 기존에 `User` 도메인에 있었으나, 이번 리팩토링 과정에서 `UserQueryPort`의 반환 타입을 맞추기 위해 `InstructorResult` 변환 과정이 추가되었습니다.

## 💡 리뷰 포인트
- `Result` -> `Response` 변환 로직(`from` 메서드)에 누락된 필드가 없는지 확인 부탁드립니다.

## ✅ 테스트
- [x] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과 (기존 테스트 코드 수정 필요할 수 있음)
- [x] API 수동 테스트 (강의 생성, 조회, 수정 정상 동작 확인)

## 📸 참고(스크린샷 / API 예시)
(API 응답 결과는 기존과 동일함)