### PR TITLE
[FEAT] 로깅 필터 추가

### DIFF
--- a/src/main/java/com/lxp/aplus/common/common/RequestLoggingFilter.java
+++ b/src/main/java/com/lxp/aplus/common/common/RequestLoggingFilter.java
@@ -1,0 +1,79 @@
+package com.lxp.aplus.common.common;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Component
+public class RequestLoggingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        // 1. 요청 내용을 여러 번 읽을 수 있도록 래핑
+        ContentCachingRequestWrapper wrappingRequest = new ContentCachingRequestWrapper(request);
+        ContentCachingResponseWrapper wrappingResponse = new ContentCachingResponseWrapper(response);
+
+        long startTime = System.currentTimeMillis();
+        try {
+            // 2. 다음 필터/컨트롤러 실행
+            filterChain.doFilter(wrappingRequest, wrappingResponse);
+        } finally {
+            long duration = System.currentTimeMillis() - startTime;
+
+            // 3. 요청/응답 로그 출력
+            logRequest(wrappingRequest);
+            logResponse(wrappingResponse, duration);
+
+            // 4. 응답 본문을 다시 클라이언트에게 전달 (필수!)
+            wrappingResponse.copyBodyToResponse();
+        }
+    }
+
+    private void logRequest(ContentCachingRequestWrapper request) {
+        String queryString = request.getQueryString() == null ? "" : "?" + request.getQueryString();
+        
+        log.info("============== [HTTP Request] ==============");
+        log.info("Method  : {}", request.getMethod());
+        log.info("URL     : {}{}", request.getRequestURI(), queryString);
+        log.info("Headers : Authorization={}", request.getHeader("Authorization")); // 필요한 헤더만 로깅
+        
+        // Body 로깅 (JSON인 경우만)
+        if (isJson(request.getContentType())) {
+            String body = new String(request.getContentAsByteArray(), StandardCharsets.UTF_8);
+            // 너무 긴 바디는 잘라서 출력 (선택사항)
+            if (!body.isEmpty()) {
+                log.info("Body    : {}", body);
+            }
+        }
+        log.info("============================================");
+    }
+
+    private void logResponse(ContentCachingResponseWrapper response, long duration) {
+        log.info("============= [HTTP Response] ==============");
+        log.info("Status  : {}", response.getStatus());
+        log.info("Time    : {} ms", duration);
+        
+        // Body 로깅
+        if (isJson(response.getContentType()) && response.getContentAsByteArray().length > 0) {
+            String body = new String(response.getContentAsByteArray(), StandardCharsets.UTF_8);
+            log.info("Body    : {}", body);
+        }
+        log.info("============================================");
+    }
+    
+    private boolean isJson(String contentType) {
+        return contentType != null && contentType.contains("application/json");
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ✨ 요약
프론트엔드와의 통신 과정에서 발생하는 HTTP 요청 및 응답 데이터를 서버 로그로 확인하여 디버깅 편의성을 높이기 위해 로깅 필터를 추가했습니다.

## 📝 작업 내용
- RequestLoggingFilter 추가 (com.lxp.aplus.common.config)
- OncePerRequestFilter를 상속받아 모든 요청에 대해 한 번씩 실행되도록 구현
- ContentCachingRequestWrapper, ContentCachingResponseWrapper를 사용하여 InputStream/OutputStream을 여러 번 읽을 수 있도록 래핑 (Body 로깅 지원)
- Request 로그: Method, URL, QueryString, Authorization 헤더, JSON Body 출력
- Response 로그: Status Code, 소요 시간(ms), JSON Body 출력
- copyBodyToResponse()를 호출하여 응답 본문이 클라이언트에게 정상적으로 전달되도록 처리

## 💭 주의 사항
- ContentCachingResponseWrapper를 사용할 때 copyBodyToResponse()를 누락하면 클라이언트가 빈 응답을 받게 되므로 주의가 필요합 니다. (현재 구현에 포함됨)
- 요청/응답 Body가 JSON 타입인 경우에만 내용을 로깅하도록 설정했습니다 (isJson 메서드).
파일 업로드(multipart/form-data) 요청의 경우 Body 로깅이 제한될 수 있습니다.

## 💡 리뷰 포인트
- 로그 포맷(INFO 레벨)이 가독성이 좋은지 확인 부탁드립니다.
- 민감한 정보(비밀번호 등)가 로그에 그대로 노출될 가능성이 있는데, 추후 마스킹 처리가 필요할지 의견 주시면 좋겠습니다.

## ✅ 테스트
[x] 로컬 빌드/실행
[ ] 단위 테스트 추가/통과
[x] API 수동 테스트 (로그 출력 확인)
