### PR TITLE
hotfix(reviews): fly-away sql수정 및 V3추가

### DIFF
--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -181,18 +181,3 @@ create table if not exists roles
         foreign key (user_id) references users (id)
 );
 
-create table if not exists reviews
-(
-    id         bigint auto_increment
-        primary key,
-    created_at datetime(6)                                        not null,
-    updated_at datetime(6)                                        not null,
-    content    varchar(2000)                                      not null,
-    course_id  bigint                                             not null,
-    deleted_at datetime(6)                                        null,
-    rating     tinyint unsigned                                   not null,
-    reported   int                                                not null,
-    status     enum ('ARCHIVED', 'BLINDED', 'DELETED', 'DISPLAY') not null,
-    user_id    bigint                                             not null
-);
-

--- a/src/main/resources/db/migration/V3__create_reviews_table.sql
+++ b/src/main/resources/db/migration/V3__create_reviews_table.sql
@@ -1,0 +1,14 @@
+create table if not exists reviews
+(
+    id         bigint auto_increment
+    primary key,
+    created_at datetime(6)                                        not null,
+    updated_at datetime(6)                                        not null,
+    content    varchar(2000)                                      not null,
+    course_id  bigint                                             not null,
+    deleted_at datetime(6)                                        null,
+    rating     tinyint unsigned                                   not null,
+    reported   int                                                not null,
+    status     enum ('ARCHIVED', 'BLINDED', 'DELETED', 'DISPLAY') not null,
+    user_id    bigint                                             not null
+    );


### PR DESCRIPTION
## ✨ 요약
fly-away sql수정 및 V3추가

## 📝 작업 내용
기존의 v1에 추가되었던 reviews DDL 삭제 및 V3_create_review_table.sql로 분리

## 💭 주의 사항

## 💡 리뷰 포인트

## ✅ 테스트
- [x] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [ ] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
