### PR TITLE
[FEAT] 마이페이지 수강코스 조회시 리뷰 작성 체크 구현

### DIFF
--- a/http/cart.http
+++ b/http/cart.http
@@ -1,0 +1,40 @@
+##########################################
+### 장바구니 API (/api/cart)
+##########################################
+
+@baseUrl = http://localhost:8080
+@contentType = application/json
+
+### 1. 장바구니 강좌 추가
+# - 성공 시 응답 바디에서 cartItemId를 추출하여 글로벌 변수에 저장합니다.
+POST {{baseUrl}}/api/cart/items
+Content-Type: {{contentType}}
+Authorization: Bearer {{accessToken}}
+
+{
+  "courseId": 1
+}
+
+> {%
+    // 응답 데이터에서 cartItemId 추출
+    // 결과 구조가 ResultResponse<CartAddItemResponse>이므로 response.body.data 접근
+    const cartItemId = response.body.data.cartItemId;
+
+    if (cartItemId) {
+        client.global.set("lastAddedCartItemId", cartItemId);
+        client.log("Cart Item ID saved: " + cartItemId);
+    } else {
+        client.log("Error: cartItemId not found in response.");
+    }
+%}
+
+
+### 2. 장바구니 강좌 삭제
+# - 1번 API 실행 후 저장된 lastAddedCartItemId 변수를 사용하여 삭제합니다.
+DELETE {{baseUrl}}/api/cart/items/{{lastAddedCartItemId}}
+Content-Type: {{contentType}}
+Authorization: Bearer {{accessToken}}
+
+> {%
+    client.log("Attempting to delete cartItemId: " + client.global.get("lastAddedCartItemId"));
+%}

--- a/http/review-api.http
+++ b/http/review-api.http
@@ -7,7 +7,7 @@
 @contentType = application/json
 
 ### 테스트용 사용자 정보 (통일)
-@testEmail = test2@example.com
+@testEmail = test3@example.com
 @testPassword = password123
 @testName = 테스트 사용자3
 @testNickName = testuser3
@@ -127,3 +127,12 @@ Authorization: Bearer {{accessToken}}
 DELETE {{baseUrl}}/api/courses/{{courseId}}/review
 Content-Type: {{contentType}}
 Authorization: Bearer {{accessToken}}
+
+### 리뷰작성 체크
+POST {{baseUrl}}/api/reviews/my
+Content-Type: {{contentType}}
+Authorization: Bearer {{accessToken}}
+
+{
+    "courseIds" :[1,2,3]
+}

--- a/src/main/java/com/lxp/aplus/common/error/code/CartErrorCode.java
+++ b/src/main/java/com/lxp/aplus/common/error/code/CartErrorCode.java
@@ -1,0 +1,19 @@
+package com.lxp.aplus.common.error.code;
+
+import com.lxp.aplus.common.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CartErrorCode implements ErrorCode {
+
+    CART_DUPLICATED_CART_ITEM(HttpStatus.CONFLICT, "EO001", "이미 담긴 항목입니다."),
+    CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "EO002", "장바구니 항목이 존재하지 않습니다."),
+    CART_CANNOT_ADD_UNPUBLISHED_COURSE(HttpStatus.BAD_REQUEST, "EO003", "현재 판매 중이지 않은 강좌는 장바구니에 담을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/lxp/aplus/common/result/code/CartResultCode.java
+++ b/src/main/java/com/lxp/aplus/common/result/code/CartResultCode.java
@@ -1,0 +1,20 @@
+package com.lxp.aplus.common.result.code;
+
+
+import com.lxp.aplus.common.result.ResultCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CartResultCode implements ResultCode {
+
+    CART_GET_ITEMS_SUCCESS(HttpStatus.OK, "SO001", "장바구니 목록 조회가 완료되었습니다."),
+    CART_ADD_ITEM_SUCCESS(HttpStatus.CREATED, "SO002", "장바구니에 강좌가 추가되었습니다."),
+    CART_REMOVE_ITEM_SUCCESS(HttpStatus.OK, "SO003", "장바구니에서 강좌가 삭제되었습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/lxp/aplus/common/security/SecurityConfig.java
+++ b/src/main/java/com/lxp/aplus/common/security/SecurityConfig.java
@@ -65,7 +65,7 @@ public class SecurityConfig {
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource(
-            @Value("${cors.allowed-origins}") List<String> allowedOrigins) {
+            @Value("#{'${cors.allowed-origins}'.split(',')}") List<String> allowedOrigins) {
         CorsConfiguration config = new CorsConfiguration();
         
         // 허용할 Origin 설정 (application.yml에서 읽어옴)

--- a/src/main/java/com/lxp/aplus/order/application/command/CartAddItemCommand.java
+++ b/src/main/java/com/lxp/aplus/order/application/command/CartAddItemCommand.java
@@ -1,0 +1,10 @@
+package com.lxp.aplus.order.application.command;
+
+import lombok.Builder;
+
+@Builder
+public record CartAddItemCommand(
+        Long userId,
+        Long courseId
+) {
+}

--- a/src/main/java/com/lxp/aplus/order/application/command/CartRemoveItemCommand.java
+++ b/src/main/java/com/lxp/aplus/order/application/command/CartRemoveItemCommand.java
@@ -1,0 +1,13 @@
+package com.lxp.aplus.order.application.command;
+
+import lombok.Builder;
+
+@Builder
+public record CartRemoveItemCommand(
+        Long userId,
+        Long cartItemId
+) {
+    public static CartRemoveItemCommand of(Long userId, Long cartItemId) {
+        return new CartRemoveItemCommand(userId, cartItemId);
+    }
+}

--- a/src/main/java/com/lxp/aplus/order/application/port/out/CourseQueryPort.java
+++ b/src/main/java/com/lxp/aplus/order/application/port/out/CourseQueryPort.java
@@ -1,0 +1,17 @@
+package com.lxp.aplus.order.application.port.out;
+
+import java.util.List;
+import java.util.Map;
+
+public interface CourseQueryPort {
+
+    /**
+     * 특정 강좌가 PUBLISHED 상태인지 확인한다.
+     */
+    boolean isCoursePublished(Long courseId);
+
+    /*
+     * course별 판매 상태(가격, 상태) 조회
+     */
+    Map<Long, CourseSalesStatus> getCourseSalesStatusByIds(List<Long> courseIds);
+}

--- a/src/main/java/com/lxp/aplus/order/application/port/out/CourseSalesStatus.java
+++ b/src/main/java/com/lxp/aplus/order/application/port/out/CourseSalesStatus.java
@@ -1,0 +1,9 @@
+package com.lxp.aplus.order.application.port.out;
+
+import com.lxp.aplus.course.domain.CourseStatus;
+
+public record CourseSalesStatus(
+        Integer price,
+        CourseStatus status
+) {
+}

--- a/src/main/java/com/lxp/aplus/order/application/usecase/CartCommandUseCase.java
+++ b/src/main/java/com/lxp/aplus/order/application/usecase/CartCommandUseCase.java
@@ -1,0 +1,100 @@
+package com.lxp.aplus.order.application.usecase;
+
+import com.lxp.aplus.common.error.BusinessException;
+import com.lxp.aplus.common.error.code.CartErrorCode;
+import com.lxp.aplus.course.domain.CourseStatus;
+import com.lxp.aplus.order.application.command.CartAddItemCommand;
+import com.lxp.aplus.order.application.command.CartRemoveItemCommand;
+import com.lxp.aplus.order.application.port.out.CourseQueryPort;
+import com.lxp.aplus.order.application.port.out.CourseSalesStatus;
+import com.lxp.aplus.order.domain.Cart;
+import com.lxp.aplus.order.domain.CartRepository;
+import com.lxp.aplus.order.presentation.response.CartAddItemResponse;
+import com.lxp.aplus.order.presentation.response.CartRemoveItemResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CartCommandUseCase {
+
+    private final CartRepository cartRepository;
+    private final CourseQueryPort courseQueryPort;
+
+    /*
+     * 장바구니에 강좌 항목을 추가한다.
+     * - 추가 후 장바구니의 실시간 상태를 반영하기 위해 전체 금액을 재계산한다.
+     * - Port를 통해 외부 도메인(Course)의 가격 정보를 간접적으로 참조한다.
+     */
+    public CartAddItemResponse addCartItemToCart(CartAddItemCommand command) {
+
+        // 1. 요청된 강좌가 발행된 상태인지 검사
+        if (!courseQueryPort.isCoursePublished(command.courseId())) {
+            throw new BusinessException(CartErrorCode.CART_CANNOT_ADD_UNPUBLISHED_COURSE);
+        }
+
+        // 2. cart 조회 (없으면 생성)
+        Cart cart = getCart(command.userId());
+
+        // 3. cart에 새로운 cartItem 추가
+        cart.addCartItem(command.courseId());
+
+        // 4. PK 생성을 위해 명시적으로 저장
+        cartRepository.save(cart);
+
+        // 5. 장바구니에 담긴 모든 강좌의 가격 조회
+        int amount = calculateCartAmount(cart);
+
+        return CartAddItemResponse.of(cart, command.courseId(), amount);
+    }
+
+    /*
+     * 장바구니에서 특정 항목을 제거한다.
+     */
+    public CartRemoveItemResponse removeCartItemFromCart(CartRemoveItemCommand command) {
+        // 1. cart 조회 (없으면 생성)
+        Cart cart = getCart(command.userId());
+
+        // 2. cart에서 항목 제거 (dirty checking)
+        cart.removeCartItem(command.cartItemId());
+
+        // 3. 장바구니에 담긴 모든 강좌의 가격 조회
+        int amount = calculateCartAmount(cart);
+
+        return CartRemoveItemResponse.of(cart, command.cartItemId(), amount);
+    }
+
+    /*
+     * 사용자별 장바구니를 조회하거나, 없을 경우 새 장바구니를 생성하여 반환한다.
+     */
+    private Cart getCart(Long userId) {
+        return cartRepository.findByUserId(userId)
+                .orElseGet(() -> cartRepository.save(Cart.create(userId)));
+    }
+
+    /*
+     * 장바구니에 담긴 강좌들의 가격 합계를 계산한다.
+     * - 장바구니에 삭제된 강좌들이 포함되어 있을 수 있으므로 PUBLISHED 강좌 가격만 계산한다.
+     */
+    private int calculateCartAmount(Cart cart) {
+        Map<Long, CourseSalesStatus> courseSalesStatusMap = courseQueryPort.getCourseSalesStatusByIds(cart.getCourseIds());
+
+        return cart.getCartItems().stream()
+                .mapToInt(cartItem -> {
+                    CourseSalesStatus courseSalesStatus = courseSalesStatusMap.get(cartItem.getCourseId());
+
+                    // PUBLISHED 강좌만 가격 반환
+                    if (courseSalesStatus != null && courseSalesStatus.status() == CourseStatus.PUBLISHED) {
+                        return courseSalesStatus.price();
+                    }
+
+                    // DELETED 강좌는 0원 처리
+                    return 0;
+                })
+                .sum();
+    }
+}

--- a/src/main/java/com/lxp/aplus/order/application/usecase/CartQueryUseCase.java
+++ b/src/main/java/com/lxp/aplus/order/application/usecase/CartQueryUseCase.java
@@ -1,0 +1,21 @@
+package com.lxp.aplus.order.application.usecase;
+
+import com.lxp.aplus.order.domain.CartItem;
+import com.lxp.aplus.order.domain.CartRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CartQueryUseCase {
+
+    private final CartRepository cartRepository;
+
+    //public List<CartItem> getCartItems(Long userId) {
+    //
+    //}
+}

--- a/src/main/java/com/lxp/aplus/order/cart-overview.md
+++ b/src/main/java/com/lxp/aplus/order/cart-overview.md
@@ -1,0 +1,77 @@
+# 🛒 Cart Bounded Context Overview
+
+## 1. 개요
+**Cart Bounded Context**는 사용자가 구매를 희망하는 강의를 임시 보관하는 영역입니다.
+단순한 저장소 역할을 넘어, 외부 도메인(Course)과의 통신을 통해 실시간 가격을 반영하고 최종 결제(Order) 단계로 넘어가기 위한 데이터를 준비하는 핵심 비즈니스 로직을 담당합니다.
+
+<br>
+
+## 2. 핵심 비즈니스 규칙 (Business Rules)
+- **1인 1바구니 보장**: 모든 사용자는 유일한 장바구니를 가집니다. (UserId - Cart : 1:1)
+- **중복 담기 방지**: 동일한 강좌(CourseId)를 중복해서 담을 수 없으며, 시도 시 도메인 예외를 발생시킵니다.
+- **실시간 가격 동기화**: 장바구니에 담긴 금액은 고정값이 아니며, 조회/추가/삭제 시점에 `CourseQueryPort`를 통해 최신 가격을 가져와 재계산합니다.
+- **Aggregate 관리**: `CartItem`은 독립적으로 존재할 수 없으며, 반드시 Aggregate Root인 `Cart`를 통해서만 생명주기가 관리됩니다.
+
+## 3. 컨텍스트 맵 (Context Map)
+장바구니는 타 도메인과의 결합도를 낮추기 위해 **Port & Adapter** 구조를 채택하고 있습니다.
+
+
+
+- **Course Context (Upstream)**: 강좌 정보 및 가격 정보를 제공받습니다.
+- **Order Context (Downstream)**: 장바구니 데이터를 기반으로 실제 주문 프로세스를 시작합니다.
+
+---
+
+## 4. 도메인 모델 (Domain Model)
+
+### **Cart (Aggregate Root)**
+| 필드 | 타입 | 설명 |
+| :--- | :--- | :--- |
+| `id` | Long | 고유 식별자 (PK) |
+| `userId` | Long | 사용자 식별자 (Unique Index) |
+| `cartItems` | List | 장바구니에 담긴 아이템 목록 (`orphanRemoval = true`) |
+
+### **CartItem (Entity)**
+| 필드 | 타입 | 설명 |
+| :--- | :--- | :--- |
+| `id` | Long | 고유 식별자 (PK) |
+| `courseId` | Long | 대상 강의 식별자 (FK 성격) |
+
+---
+
+## 5. 주요 유스케이스 흐름 (Key Use Case Flow)
+
+### **강좌 추가 (Add Item)**
+1. `CartRepository`에서 사용자의 장바구니 조회 (미존재 시 자동 생성 후 영속화).
+2. `Cart.addCartItem(courseId)` 호출을 통해 중복 검증 및 아이템 추가.
+3. `CourseQueryPort`를 통해 현재 장바구니에 담긴 모든 `courseIds`의 최신 가격 Map 조회.
+4. `Cart.calculateAmount(priceMap)`로 최종 합계 계산 후 응답 반환.
+
+### **강좌 삭제 (Remove Item)**
+1. 사용자의 장바구니 조회.
+2. `Cart.removeCartItem(cartItemId)` 호출.
+    - 리스트에서 해당 객체를 제거하면 `orphanRemoval = true` 설정에 의해 DB 데이터도 자동 삭제됨.
+3. 삭제 후 남은 항목들에 대해 가격을 재조회하여 최신 총액(Amount) 계산.
+4. 삭제된 ID와 갱신된 총액을 포함하여 응답 반환.
+
+---
+
+## 6. 기술적 의사결정 기록 (Technical Decisions)
+
+### **JPA 변경 감지(Dirty Checking) 활용**
+- **결정**: 삭제 로직에서 명시적인 `delete` 쿼리 대신 리스트 조작을 통한 변경 감지 방식을 사용합니다.
+- **이유**: 객체 지향적인 관점에서 부모가 자식의 생명주기를 관리하게 함으로써 데이터 무결성을 높이기 위함입니다.
+
+### **Objects.equals 기반의 ID 비교**
+- **결정**: 아이템 제거 시 `Objects.equals(a, b)`를 사용합니다.
+- **이유**: 단위 테스트 시나 영속화 전 단계에서 발생할 수 있는 `null` ID에 의한 `NullPointerException`을 방어하기 위함입니다.
+
+### **Port 인터페이스 분리**
+- **결정**: 가격 조회를 직접 DB 조인이 아닌 별도의 `Port` 인터페이스로 분리하였습니다.
+- **이유**: 향후 Course 서비스가 별도의 MSA로 분리되더라도 도메인 로직의 수정 없이 Adapter(API 호출 등)만 교체하기 위함입니다.
+
+---
+
+## 7. 관련 엔드포인트
+- `POST /api/v1/carts/items` (장바구니 항목 추가)
+- `DELETE /api/v1/carts/items/{cartItemId}` (장바구니 항목 삭제)

--- a/src/main/java/com/lxp/aplus/order/domain/Cart.java
+++ b/src/main/java/com/lxp/aplus/order/domain/Cart.java
@@ -1,0 +1,87 @@
+package com.lxp.aplus.order.domain;
+
+import com.lxp.aplus.common.domain.BaseAggregateRoot;
+import com.lxp.aplus.common.error.BusinessException;
+import com.lxp.aplus.common.error.code.CartErrorCode;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.*;
+
+@Entity
+@Table(name = "carts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Cart extends BaseAggregateRoot {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    @OneToMany(
+            mappedBy = "cart",
+            cascade = CascadeType.ALL,
+            /*
+             * - orphanRemoval = true: cartItems 리스트에서 요소가 제거되면, DB에서도 해당 행을 자동으로 삭제
+             *   (즉, CartItem은 오직 Cart에 의해서만 생명주기가 관리되는 종속적인 존재임을 명시)
+            */
+            orphanRemoval = true
+    )
+    private final List<CartItem> cartItems = new ArrayList<>();
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public Cart(Long userId) {
+        this.userId = userId;
+    }
+
+    // === 생성 메서드 ===
+
+    public static Cart create(Long userId) {
+        return Cart.builder()
+                .userId(userId)
+                .build();
+    }
+
+    // === 도메인 행위 ===
+
+    public List<CartItem> getCartItems() {
+        // 읽기 전용 상태로 감싸서 반환 (도메인 무결성 보호)
+        // 같은 이름의 메서드면 Lombok은 getter를 생성하지 않음!
+        return Collections.unmodifiableList(cartItems);
+    }
+
+    public void addCartItem(Long courseId) {
+        if (contains(courseId)) {
+            throw new BusinessException(CartErrorCode.CART_DUPLICATED_CART_ITEM);
+        }
+
+        cartItems.add(CartItem.create(this, courseId));
+    }
+
+    public void removeCartItem(Long cartItemId) {
+        /*
+         * - Objects.equals: cartItem.getId()가 null인 경우(영속화 전)에도 NPE 없이 안전하게 비교하기 위함
+         * - removeIf: 조건에 맞는 요소를 리스트에서 즉시 제거 (orphanRemoval=true 설정에 의해 DB 삭제 전파)
+         */
+        boolean removed = cartItems.removeIf(cartItem -> Objects.equals(cartItem.getId(), cartItemId));
+
+        if (!removed) {
+            throw new BusinessException(CartErrorCode.CART_ITEM_NOT_FOUND);
+        }
+    }
+
+    public List<Long> getCourseIds() {
+        return cartItems.stream()
+                .map(CartItem::getCourseId)
+                .toList();
+    }
+
+    private boolean contains(Long courseId) {
+        return cartItems.stream().anyMatch(i -> i.has(courseId));
+    }
+}

--- a/src/main/java/com/lxp/aplus/order/domain/CartItem.java
+++ b/src/main/java/com/lxp/aplus/order/domain/CartItem.java
@@ -1,0 +1,53 @@
+package com.lxp.aplus.order.domain;
+
+import com.lxp.aplus.common.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "cart_items",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        // 같은 강의를 중복으로 담지 못하도록 DB 레벨에서 보장
+                        name = "uk_cart_course",
+                        columnNames = {"cart_id", "course_id"}
+                )
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CartItem extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cart_id", nullable = false)
+    private Cart cart;
+
+    @Column(name = "course_id", nullable = false)
+    private Long courseId;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private CartItem(Cart cart, Long courseId) {
+        this.cart = cart;
+        this.courseId = courseId;
+    }
+
+    // === 생성 메서드 ===
+
+    public static CartItem create(Cart cart, Long courseId) {
+        return CartItem.builder()
+                .cart(cart)
+                .courseId(courseId)
+                .build();
+    }
+
+    // === 도메인 행위 ===
+
+    public boolean has(Long courseId) {
+        return this.courseId.equals(courseId);
+    }
+}

--- a/src/main/java/com/lxp/aplus/order/domain/CartRepository.java
+++ b/src/main/java/com/lxp/aplus/order/domain/CartRepository.java
@@ -1,0 +1,10 @@
+package com.lxp.aplus.order.domain;
+
+import java.util.Optional;
+
+public interface CartRepository {
+
+    Optional<Cart> findByUserId(Long userId);
+
+    Cart save(Cart cart);
+}

--- a/src/main/java/com/lxp/aplus/order/infrastructure/adapter/CourseQueryAdapter.java
+++ b/src/main/java/com/lxp/aplus/order/infrastructure/adapter/CourseQueryAdapter.java
@@ -1,0 +1,67 @@
+package com.lxp.aplus.order.infrastructure.adapter;
+
+import com.lxp.aplus.common.error.BusinessException;
+import com.lxp.aplus.common.error.code.CourseErrorCode;
+import com.lxp.aplus.course.domain.Course;
+import com.lxp.aplus.course.domain.CourseRepository;
+import com.lxp.aplus.course.domain.CourseStatus;
+import com.lxp.aplus.order.application.port.out.CourseQueryPort;
+import com.lxp.aplus.order.application.port.out.CourseSalesStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/*
+ * [주문 도메인 연동 어댑터 - MSA 분리 가이드]
+ * - 현재: 동일 프로세스 내 CourseRepository 직접 호출 (In-process)
+ * - 전환 시:
+ * 1) 동기식 REST 통신 필요 시: OpenFeign 또는 RestClient 적용
+ * 2) 고성능/타입 안정성 필요 시: gRPC Stub 적용
+ * 3) 어느 방식을 선택하든 CourseQueryPort의 인터페이스 정의는 유지함
+ */
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CourseQueryAdapter implements CourseQueryPort {
+
+    // FIXME: Course BC 침범 (의도됨) ⚠️
+    // TODO: Repository 대신 HTTP/gRPC를 호출하는 외부 모듈 주입
+    private final CourseRepository courseRepository;
+
+    /**
+     * 단일 강좌의 판매 가능 여부 확인
+     * @param courseId 강좌 식별자
+     * @return PUBLISHED 상태 여부
+     */
+    public boolean isCoursePublished(Long courseId) {
+        return courseRepository.findById(courseId)
+                .map(course -> course.getCourseStatus() == CourseStatus.PUBLISHED)
+                .orElse(false);
+    }
+
+    /**
+     * 다건 강좌의 판매 정보(가격, 상태) 일괄 조회
+     * @param courseIds 강좌 식별자 리스트
+     * @return 강좌 ID를 키로 하는 판매 정보 맵 (CourseSalesStatus)
+     * @throws BusinessException 요청한 ID 중 하나라도 DB에 없을 경우 COURSE_NOT_FOUND 발생
+     */
+    public Map<Long, CourseSalesStatus> getCourseSalesStatusByIds(List<Long> courseIds) {
+
+        List<Course> courses = courseRepository.findByIdIn(courseIds);
+
+        if (courses.size() != courseIds.size()) {
+            // TODO: 비즈니스 요구사항에 따라 누락된 ID 목록을 로깅하거나 예외 메시지에 포함하는 것 검토
+            throw new BusinessException(CourseErrorCode.COURSE_NOT_FOUND);
+        }
+
+        return courses.stream()
+                .collect(Collectors.toMap(
+                        Course::getId,
+                        course -> new CourseSalesStatus(course.getPrice(), course.getCourseStatus())
+                ));
+    }
+}

--- a/src/main/java/com/lxp/aplus/order/infrastructure/persistence/CartJpaRepository.java
+++ b/src/main/java/com/lxp/aplus/order/infrastructure/persistence/CartJpaRepository.java
@@ -1,0 +1,11 @@
+package com.lxp.aplus.order.infrastructure.persistence;
+
+import com.lxp.aplus.order.domain.Cart;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CartJpaRepository extends JpaRepository<Cart, Long> {
+
+    Optional<Cart> findByUserId(Long userId);
+}

--- a/src/main/java/com/lxp/aplus/order/infrastructure/persistence/CartRepositoryImpl.java
+++ b/src/main/java/com/lxp/aplus/order/infrastructure/persistence/CartRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.lxp.aplus.order.infrastructure.persistence;
+
+import com.lxp.aplus.order.domain.Cart;
+import com.lxp.aplus.order.domain.CartRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class CartRepositoryImpl implements CartRepository {
+
+    private final CartJpaRepository jpaRepository;
+
+    @Override
+    public Optional<Cart> findByUserId(Long userId) {
+        return jpaRepository.findByUserId(userId);
+    }
+
+    @Override
+    public Cart save(Cart cart) {
+        return jpaRepository.save(cart);
+    }
+}

--- a/src/main/java/com/lxp/aplus/order/presentation/controller/CartController.java
+++ b/src/main/java/com/lxp/aplus/order/presentation/controller/CartController.java
@@ -1,0 +1,50 @@
+package com.lxp.aplus.order.presentation.controller;
+
+import com.lxp.aplus.common.result.ResultResponse;
+import com.lxp.aplus.common.security.Authenticated;
+import com.lxp.aplus.order.application.command.CartRemoveItemCommand;
+import com.lxp.aplus.order.application.usecase.CartCommandUseCase;
+import com.lxp.aplus.order.presentation.request.CartAddItemRequest;
+import com.lxp.aplus.order.presentation.response.CartAddItemResponse;
+import com.lxp.aplus.order.presentation.response.CartRemoveItemResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static com.lxp.aplus.common.result.code.CartResultCode.CART_ADD_ITEM_SUCCESS;
+import static com.lxp.aplus.common.result.code.CartResultCode.CART_REMOVE_ITEM_SUCCESS;
+
+@RestController
+@RequestMapping("/api/cart")
+@RequiredArgsConstructor
+public class CartController {
+
+    private final CartCommandUseCase cartCommandUseCase;
+
+    @PostMapping("/items")
+    public ResponseEntity<ResultResponse<CartAddItemResponse>> addCartItem(
+            @Authenticated Long userId,
+            @RequestBody @Valid CartAddItemRequest request
+    ) {
+
+        CartAddItemResponse response = cartCommandUseCase.addCartItemToCart(request.toCommand(userId));
+
+        return ResponseEntity
+                .status(CART_ADD_ITEM_SUCCESS.getStatus())
+                .body(ResultResponse.of(CART_ADD_ITEM_SUCCESS, response));
+    }
+
+    @DeleteMapping("/items/{cartItemId}")
+    public ResponseEntity<ResultResponse<CartRemoveItemResponse>> removeCartItem(
+            @Authenticated Long userId,
+            @PathVariable Long cartItemId
+    ) {
+        CartRemoveItemCommand command = CartRemoveItemCommand.of(userId, cartItemId);
+        CartRemoveItemResponse response = cartCommandUseCase.removeCartItemFromCart(command);
+
+        return ResponseEntity
+                .status(CART_REMOVE_ITEM_SUCCESS.getStatus())
+                .body(ResultResponse.of(CART_REMOVE_ITEM_SUCCESS, response));
+    }
+}

--- a/src/main/java/com/lxp/aplus/order/presentation/request/CartAddItemRequest.java
+++ b/src/main/java/com/lxp/aplus/order/presentation/request/CartAddItemRequest.java
@@ -1,0 +1,16 @@
+package com.lxp.aplus.order.presentation.request;
+
+import com.lxp.aplus.order.application.command.CartAddItemCommand;
+import jakarta.validation.constraints.NotNull;
+
+public record CartAddItemRequest(
+        @NotNull(message = "강좌 ID는 필수입니다.")
+        Long courseId
+) {
+    public CartAddItemCommand toCommand(Long userId) {
+        return CartAddItemCommand.builder()
+                .userId(userId)
+                .courseId(this.courseId)
+                .build();
+    }
+}

--- a/src/main/java/com/lxp/aplus/order/presentation/response/CartAddItemResponse.java
+++ b/src/main/java/com/lxp/aplus/order/presentation/response/CartAddItemResponse.java
@@ -1,0 +1,30 @@
+package com.lxp.aplus.order.presentation.response;
+
+import com.lxp.aplus.common.error.BusinessException;
+import com.lxp.aplus.common.error.code.CartErrorCode;
+import com.lxp.aplus.order.domain.Cart;
+import com.lxp.aplus.order.domain.CartItem;
+import lombok.Builder;
+
+@Builder
+public record CartAddItemResponse(
+        Long cartId,
+        Long cartItemId,
+        int amount
+) {
+    public static CartAddItemResponse of(Cart cart, Long addedCourseId, int amount) {
+
+        // 리스트에서 해당 courseId를 가진 항목을 찾음
+        // TODO: dto에서 service의 책임을 지고 있음 -> 유즈케이스로 레이어로 이동
+        CartItem addedCartItem = cart.getCartItems().stream()
+                .filter(cartItem -> cartItem.getCourseId().equals(addedCourseId))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(CartErrorCode.CART_ITEM_NOT_FOUND));
+
+        return CartAddItemResponse.builder()
+                .cartId(cart.getId())
+                .cartItemId(addedCartItem.getId())  // DB에서 받아온 ID
+                .amount(amount)
+                .build();
+    }
+}

--- a/src/main/java/com/lxp/aplus/order/presentation/response/CartRemoveItemResponse.java
+++ b/src/main/java/com/lxp/aplus/order/presentation/response/CartRemoveItemResponse.java
@@ -1,0 +1,20 @@
+package com.lxp.aplus.order.presentation.response;
+
+import com.lxp.aplus.order.domain.Cart;
+import lombok.Builder;
+
+@Builder
+public record CartRemoveItemResponse(
+        Long cartId,
+        Long removedCartItemId,
+        int amount
+) {
+    public static CartRemoveItemResponse of(Cart cart, Long removedCartItemId, int amount) {
+
+        return CartRemoveItemResponse.builder()
+                .cartId(cart.getId())
+                .removedCartItemId(removedCartItemId)
+                .amount(amount)
+                .build();
+    }
+}

--- a/src/main/java/com/lxp/aplus/review/application/result/ReviewWroteResult.java
+++ b/src/main/java/com/lxp/aplus/review/application/result/ReviewWroteResult.java
@@ -1,0 +1,7 @@
+package com.lxp.aplus.review.application.result;
+
+public record ReviewWroteResult(
+        Long courseId,
+        boolean isReviewed
+) {
+}

--- a/src/main/java/com/lxp/aplus/review/application/usecase/ReviewQueryUseCase.java
+++ b/src/main/java/com/lxp/aplus/review/application/usecase/ReviewQueryUseCase.java
@@ -5,8 +5,13 @@ import com.lxp.aplus.common.error.code.ReviewErrorCode;
 import com.lxp.aplus.review.application.command.ReviewQueryCommand;
 import com.lxp.aplus.review.application.port.out.UserQueryPort;
 import com.lxp.aplus.review.application.result.ReviewResult;
+import com.lxp.aplus.review.application.result.ReviewWroteResult;
 import com.lxp.aplus.review.domain.Reviews;
 import com.lxp.aplus.review.domain.ReviewsRepository;
+import com.lxp.aplus.review.infrastructure.dto.ReviewWroteDto;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -38,5 +43,20 @@ public class ReviewQueryUseCase {
 
     public Integer countReviewsInCourse(Long courseId) {
         return reviewRepository.countCourseReviews(courseId);
+    }
+
+    public List<ReviewWroteResult> checkReviewed(List<Long> courseIds, Long userId){
+        List<ReviewWroteDto> result = reviewRepository.checkReviewedByCourseIds(courseIds, userId);
+
+        Set<Long> writtenIds = result.stream()
+                .map(ReviewWroteDto::courseId)
+                .collect(Collectors.toSet());
+
+        return courseIds.stream()
+                .map(id -> new ReviewWroteResult(
+                        id,
+                        writtenIds.contains(id) // 작성 목록에 있으면 true, 없으면 false
+                ))
+                .toList();
     }
 }

--- a/src/main/java/com/lxp/aplus/review/domain/ReviewsRepository.java
+++ b/src/main/java/com/lxp/aplus/review/domain/ReviewsRepository.java
@@ -1,5 +1,7 @@
 package com.lxp.aplus.review.domain;
 
+import com.lxp.aplus.review.infrastructure.dto.ReviewWroteDto;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -11,4 +13,5 @@ public interface ReviewsRepository {
     Slice<Reviews> getCourseReviews(Long courseId, Pageable pageable);
     Integer countCourseReviews(Long courseId);
     Long deleteReview(Long userId, Long courseId);
+    List<ReviewWroteDto> checkReviewedByCourseIds(List<Long> courseIds, Long userId);
 }

--- a/src/main/java/com/lxp/aplus/review/infrastructure/adapter/ReviewUserQueryAdapter.java
+++ b/src/main/java/com/lxp/aplus/review/infrastructure/adapter/ReviewUserQueryAdapter.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 @Component
 @Transactional
 @RequiredArgsConstructor
-public class UserQueryAdapter implements UserQueryPort {
+public class ReviewUserQueryAdapter implements UserQueryPort {
     private final UserRepository userRepository;
 
     @Override

--- a/src/main/java/com/lxp/aplus/review/infrastructure/dto/ReviewWroteDto.java
+++ b/src/main/java/com/lxp/aplus/review/infrastructure/dto/ReviewWroteDto.java
@@ -1,0 +1,11 @@
+package com.lxp.aplus.review.infrastructure.dto;
+
+import com.lxp.aplus.review.domain.Reviews;
+
+public record ReviewWroteDto(
+        Long courseId
+) {
+    public static ReviewWroteDto from(Reviews reviews) {
+        return new ReviewWroteDto(reviews.getCourseId());
+    }
+}

--- a/src/main/java/com/lxp/aplus/review/infrastructure/persistence/ReviewsJpaRepository.java
+++ b/src/main/java/com/lxp/aplus/review/infrastructure/persistence/ReviewsJpaRepository.java
@@ -2,6 +2,8 @@ package com.lxp.aplus.review.infrastructure.persistence;
 
 import com.lxp.aplus.review.domain.Reviews;
 import com.lxp.aplus.review.domain.constant.ReviewStatus;
+import com.lxp.aplus.review.infrastructure.dto.ReviewWroteDto;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -13,4 +15,5 @@ public interface ReviewsJpaRepository extends JpaRepository<Reviews, Long> {
     Integer countByCourseId(Long courseId);
     Optional<Reviews> findByUserIdAndCourseIdAndStatus(Long userId, Long courseId, ReviewStatus status);
     Long deleteByUserIdAndCourseId(Long userId, Long courseId);
+    List<Reviews> findByUserIdAndCourseIdIn(Long userId, List<Long> courseIds);
 }

--- a/src/main/java/com/lxp/aplus/review/infrastructure/persistence/ReviewsRepositoryImpl.java
+++ b/src/main/java/com/lxp/aplus/review/infrastructure/persistence/ReviewsRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.lxp.aplus.review.infrastructure.persistence;
 import com.lxp.aplus.review.domain.Reviews;
 import com.lxp.aplus.review.domain.ReviewsRepository;
 import com.lxp.aplus.review.domain.constant.ReviewStatus;
+import com.lxp.aplus.review.infrastructure.dto.ReviewWroteDto;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -42,5 +44,10 @@ public class ReviewsRepositoryImpl implements ReviewsRepository {
     @Override
     public Long deleteReview(Long userId, Long courseId) {
         return reviewJpaRepository.deleteByUserIdAndCourseId(userId, courseId);
+    }
+
+    @Override
+    public List<ReviewWroteDto> checkReviewedByCourseIds(List<Long> courseIds, Long userId) {
+        return reviewJpaRepository.findByUserIdAndCourseIdIn(userId, courseIds).stream().map(ReviewWroteDto::from).toList();
     }
 }

--- a/src/main/java/com/lxp/aplus/review/presentation/ReviewController.java
+++ b/src/main/java/com/lxp/aplus/review/presentation/ReviewController.java
@@ -10,15 +10,19 @@ import com.lxp.aplus.review.application.command.ReviewQueryCommand;
 import com.lxp.aplus.review.application.result.ReviewDeleteResult;
 import com.lxp.aplus.review.application.result.ReviewResult;
 import com.lxp.aplus.review.application.result.ReviewUpsertResult;
+import com.lxp.aplus.review.application.result.ReviewWroteResult;
 import com.lxp.aplus.review.application.usecase.ReviewCommandUseCase;
 import com.lxp.aplus.review.application.usecase.ReviewQueryUseCase;
 import com.lxp.aplus.review.presentation.request.ReviewCreateRequest;
+import com.lxp.aplus.review.presentation.request.ReviewFindCourseIdRequest;
 import com.lxp.aplus.review.presentation.request.ReviewUpdateRequest;
 import com.lxp.aplus.review.presentation.response.ReviewDeleteResponse;
 import com.lxp.aplus.review.presentation.response.ReviewResponse;
 import com.lxp.aplus.review.presentation.response.ReviewUpsertResponse;
+import com.lxp.aplus.review.presentation.response.ReviewWroteResponse;
 import com.lxp.aplus.review.presentation.response.SliceResponse;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -102,5 +106,13 @@ public class ReviewController {
 
         return ResponseEntity.status(ReviewResultCode.REVIEW_DELETE_SUCCESS.getStatus())
                 .body(ResultResponse.of(ReviewResultCode.REVIEW_DELETE_SUCCESS, ReviewDeleteResponse.from(result)));
+    }
+
+    @PostMapping("/reviews/my")
+    public ResponseEntity<ResultResponse<List<ReviewWroteResponse>>> getMyReviewsIsWrote(
+            @RequestBody ReviewFindCourseIdRequest request, @Authenticated Long userId) {
+        List<ReviewWroteResponse> result = reviewQueryUseCase.checkReviewed(request.courseIds(), userId).stream().map(ReviewWroteResponse::from).toList();
+        return ResponseEntity.status(ReviewResultCode.REVIEW_FIND_SUCCESS.getStatus())
+                .body(ResultResponse.of(ReviewResultCode.REVIEW_FIND_SUCCESS, result));
     }
 }

--- a/src/main/java/com/lxp/aplus/review/presentation/request/ReviewFindCourseIdRequest.java
+++ b/src/main/java/com/lxp/aplus/review/presentation/request/ReviewFindCourseIdRequest.java
@@ -1,0 +1,8 @@
+package com.lxp.aplus.review.presentation.request;
+
+import java.util.List;
+
+public record ReviewFindCourseIdRequest(
+        List<Long> courseIds
+) {
+}

--- a/src/main/java/com/lxp/aplus/review/presentation/response/ReviewWroteResponse.java
+++ b/src/main/java/com/lxp/aplus/review/presentation/response/ReviewWroteResponse.java
@@ -1,0 +1,12 @@
+package com.lxp.aplus.review.presentation.response;
+
+import com.lxp.aplus.review.application.result.ReviewWroteResult;
+
+public record ReviewWroteResponse(
+        Long courseId,
+        boolean isReviewed
+) {
+    public static ReviewWroteResponse from(ReviewWroteResult content) {
+        return new ReviewWroteResponse(content.courseId(), content.isReviewed());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,8 @@ server:
 spring:
   application:
     name: LXP-Project
+  profiles:
+    active: local
 
   web:
     resources:
@@ -23,9 +25,7 @@ jwt:
   prefix: Bearer
 
 cors:
-  allowed-origins:
-    - http://localhost:3000
-    - http://127.0.0.1:3000
+  allowed-origins: http://localhost:3000,http://127.0.0.1:3000
 
 logging:
   level:

--- a/src/main/resources/db/migration/V10__create_cart_and_cart_item.sql
+++ b/src/main/resources/db/migration/V10__create_cart_and_cart_item.sql
@@ -1,0 +1,19 @@
+CREATE TABLE if not exists carts
+(
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    CONSTRAINT uk_carts_user UNIQUE (user_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE if not exists cart_items
+(
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    cart_id BIGINT NOT NULL,
+    course_id BIGINT NOT NULL,
+    CONSTRAINT uk_cart_course UNIQUE (cart_id, course_id),
+    CONSTRAINT fk_cart_items_cart_id FOREIGN KEY (cart_id) REFERENCES carts (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/main/resources/db/migration/V5__create_lecture_resource_v2.sql
+++ b/src/main/resources/db/migration/V5__create_lecture_resource_v2.sql
@@ -11,19 +11,3 @@ create table if not exists lecture_resources_v2
     PRIMARY KEY (`id`)
 );
 
-INSERT INTO LECTURE_RESOURCES_V2 (created_at, updated_at, file_key, is_downloadable, original_file_name, resource_type, duration)
-SELECT
-    lr.created_at,
-    lr.updated_at,
-    lr.file_key,
-    lr.is_downloadable,
-    lr.original_file_name,
-    lr.resource_type,
-    l.total_duration_seconds
-FROM lecture_resources lr
-         JOIN lectures l ON lr.lecture_id = l.id;
-
-SELECT @max_id := COALESCE(MAX(id), 0) + 1 FROM lecture_resources_v2;
-SET @sql = CONCAT('ALTER TABLE lecture_resources_v2 AUTO_INCREMENT = ', @max_id);
-PREPARE STMT FROM @sql;
-EXECUTE STMT;

--- a/src/main/resources/db/migration/V6__migration_lecture_resource_v2.sql
+++ b/src/main/resources/db/migration/V6__migration_lecture_resource_v2.sql
@@ -1,4 +1,4 @@
-INSERT IGNORE INTO LECTURE_RESOURCES_V2 (created_at, updated_at, file_key, is_downloadable, original_file_name, resource_type, duration)
+INSERT IGNORE INTO lecture_resources_v2 (created_at, updated_at, file_key, is_downloadable, original_file_name, resource_type, duration)
 SELECT
     lr.created_at,
     lr.updated_at,

--- a/src/main/resources/db/migration/V6__migration_lecture_resource_v2.sql
+++ b/src/main/resources/db/migration/V6__migration_lecture_resource_v2.sql
@@ -1,0 +1,11 @@
+INSERT IGNORE INTO LECTURE_RESOURCES_V2 (created_at, updated_at, file_key, is_downloadable, original_file_name, resource_type, duration)
+SELECT
+    lr.created_at,
+    lr.updated_at,
+    lr.file_key,
+    lr.is_downloadable,
+    lr.original_file_name,
+    lr.resource_type,
+    l.total_duration_seconds
+FROM lecture_resources lr
+JOIN lectures l ON lr.lecture_id = l.id;

--- a/src/test/java/com/lxp/aplus/order/application/usecase/CartCommandUseCaseUnitTest.java
+++ b/src/test/java/com/lxp/aplus/order/application/usecase/CartCommandUseCaseUnitTest.java
@@ -1,0 +1,140 @@
+package com.lxp.aplus.order.application.usecase;
+
+import com.lxp.aplus.common.error.BusinessException;
+import com.lxp.aplus.order.application.command.CartAddItemCommand;
+import com.lxp.aplus.order.application.command.CartRemoveItemCommand;
+import com.lxp.aplus.order.application.port.out.CourseQueryPort;
+import com.lxp.aplus.order.domain.Cart;
+import com.lxp.aplus.order.domain.CartItem;
+import com.lxp.aplus.order.domain.CartRepository;
+import com.lxp.aplus.order.presentation.response.CartAddItemResponse;
+import com.lxp.aplus.order.presentation.response.CartRemoveItemResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CartCommandUseCase 단위 테스트")
+class CartCommandUseCaseUnitTest {
+
+    @Mock
+    private CartRepository cartRepository;
+
+    @Mock
+    private CourseQueryPort courseQueryPort;
+
+    @InjectMocks
+    private CartCommandUseCase cartCommandUseCase;
+
+    private final Long USER_ID = 1L;
+
+    // -------------------------------------------------------------------------
+    // 1. 정상 흐름 테스트 (Happy Path)
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("강좌를 장바구니에 추가하면 실시간 가격으로 총액이 계산되어야 한다")
+    void addCartItem_Success() {
+        // given
+        Cart cart = Cart.create(USER_ID);
+        Long courseId = 100L;
+        int price = 50000;
+
+        given(cartRepository.findByUserId(USER_ID)).willReturn(Optional.of(cart));
+        given(cartRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+        // 외부 포트가 가격 정보를 반환하도록 설정
+        given(courseQueryPort.getCoursePriceByIds(anyList()))
+                .willReturn(Map.of(courseId, price));
+
+        // when
+        CartAddItemResponse response = cartCommandUseCase.addCartItemToCart(new CartAddItemCommand(USER_ID, courseId));
+
+        // then: 추가된 courseId와 계산된 금액이 정확한지 확인
+        assertThat(response.amount()).isEqualTo(price);
+    }
+
+    @Test
+    @DisplayName("아이템을 삭제하면 남은 강좌들의 금액 합계가 응답되어야 한다")
+    void removeCartItem_Success() {
+        // 1. given: 장바구니 생성 및 아이템 추가
+        Cart cart = Cart.create(USER_ID);
+        cart.addCartItem(1L); // 삭제 대상이 될 아이템
+        cart.addCartItem(2L); // 남겨둘 아이템
+
+        // 2. ReflectionTestUtils로 가짜 ID(PK) 주입
+        // DB가 없는 단위 테스트 환경에서 getId()가 값을 반환하게 만듭니다.
+        CartItem item1 = cart.getCartItems().get(0);
+        CartItem item2 = cart.getCartItems().get(1);
+
+        ReflectionTestUtils.setField(item1, "id", 100L); // 삭제할 아이템의 ID를 100으로 설정
+        ReflectionTestUtils.setField(item2, "id", 200L); // 남을 아이템의 ID를 200으로 설정
+
+        Long targetItemId = 100L; // 삭제 요청할 ID
+
+        // 3. Mock 환경 설정
+        given(cartRepository.findByUserId(USER_ID)).willReturn(Optional.of(cart));
+
+        // 가격표 셋업: 삭제 후 남은 2번 강의(2L)의 가격이 필요함
+        given(courseQueryPort.getCoursePriceByIds(anyList()))
+                .willReturn(Map.of(
+                        1L, 10000,
+                        2L, 30000
+                ));
+
+        // 4. when: 삭제 실행
+        CartRemoveItemResponse response = cartCommandUseCase.removeCartItemFromCart(
+                new CartRemoveItemCommand(USER_ID, targetItemId));
+
+        // 5. then: 검증
+        // - 1번 아이템이 삭제되고, 2번 아이템(2L 강의)만 남아서 금액이 30,000원이어야 함
+        assertThat(response.amount()).isEqualTo(30000);
+        assertThat(cart.getCartItems()).hasSize(1);
+        assertThat(cart.getCourseIds()).containsExactly(2L); // 실제로 2번 강의만 남았는지 확인
+    }
+
+    // -------------------------------------------------------------------------
+    // 2. 필수 예외 테스트 (Edge Case - 장애 방지용)
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("이미 장바구니에 있는 강좌를 또 담으려고 하면 예외가 발생해야 한다")
+    void addCartItem_Duplicate_Fail() {
+        // given: 이미 100번 강좌가 담겨있음
+        Cart cart = Cart.create(USER_ID);
+        cart.addCartItem(100L);
+        given(cartRepository.findByUserId(USER_ID)).willReturn(Optional.of(cart));
+
+        // when & then: 중복 추가 시 도메인 규칙 위반으로 예외 발생 확인
+        assertThatThrownBy(() ->
+                cartCommandUseCase.addCartItemToCart(new CartAddItemCommand(USER_ID, 100L))
+        ).isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 장바구니 항목을 삭제하려 하면 예외가 발생해야 한다")
+    void removeCartItem_NotFound_Fail() {
+        // given: 빈 장바구니
+        Cart cart = Cart.create(USER_ID);
+        given(cartRepository.findByUserId(USER_ID)).willReturn(Optional.of(cart));
+
+        // when & then: 없는 ID(999L) 삭제 시도
+        assertThatThrownBy(() ->
+                cartCommandUseCase.removeCartItemFromCart(new CartRemoveItemCommand(USER_ID, 999L))
+        ).isInstanceOf(BusinessException.class);
+    }
+}


### PR DESCRIPTION
## ✨ 요약
마이페이지 수강코스 조회시 리뷰 작성 체크 구현

## 📝 작업 내용
클라이언트가 수강에서 수강중인 강의 조회 -> 강의 아이디들을 Review도메인으로 보내서 Review작성 여부 확인
[
{
     "courseId" : 1,
     "isReviewd": true
},
{
     "courseId" : 2,
     "isReviewd": false
}
]

형태로 반환

## 💭 주의 사항
급하게 만들어서 놓친 부분이 있을 수도 있습니다...
리뷰 CRUD 머지가 먼저 선행되어야 합니다.

## 💡 리뷰 포인트
로직 흐름 및 구조

## ✅ 테스트
- [x] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [x] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)


## 관련 이슈
#149 