### PR TITLE
[HOTFIX] 수강신청 로직 수정 + 묶음결제 기능

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ out/
 
 ./.env
 .env
+/src/main/resources/static/uploads

--- a/src/main/java/com/lxp/aplus/order/domain/Order.java
+++ b/src/main/java/com/lxp/aplus/order/domain/Order.java
@@ -37,12 +37,12 @@ public class Order extends BaseAggregateRoot {
     @Column(nullable = false, updatable = false, precision = 19, scale = 0)
     private BigDecimal amount;
 
-    @ElementCollection
-    @CollectionTable(
-            name = "order_lines",
-            joinColumns = @JoinColumn(name = "order_id")
+    @OneToMany(
+            mappedBy = "order",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true
     )
-    private List<OrderLine> orderLines = new ArrayList<>();
+    private List<OrderItem> orderItems = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -62,13 +62,18 @@ public class Order extends BaseAggregateRoot {
             String orderId,
             Long userId,
             BigDecimal amount,
-            List<OrderLine> orderLines
+            List<OrderItem> orderItems
     ) {
         this.orderId = orderId;
         this.userId = userId;
         this.currency = "KRW";
         this.amount = amount;
-        this.orderLines = orderLines;
+        //this.orderItems = orderItems;
+
+        for (OrderItem orderItem : orderItems) {
+            this.orderItems.add(orderItem);
+            orderItem.assignOrder(this);
+        }
     }
 
     /* ========= 생성 ========= */
@@ -80,15 +85,15 @@ public class Order extends BaseAggregateRoot {
      */
     public static Order create(
             Long userId,
-            List<OrderLine> orderLines
+            List<OrderItem> orderItems
     ) {
         // 1. orderId 생성
         // TODO: orderId 생성 규칙 만들기
         String orderId = UUID.randomUUID().toString();
 
         // 2. 총액 계산
-        BigDecimal amount = orderLines.stream()
-                .map(OrderLine::getPrice)
+        BigDecimal amount = orderItems.stream()
+                .map(OrderItem::getPrice)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
 
         // 3. Order 생성 및 반환 (생성자를 통해 불변성 확보)
@@ -96,7 +101,7 @@ public class Order extends BaseAggregateRoot {
                 orderId,
                 userId,
                 amount,
-                new ArrayList<>(orderLines)
+                new ArrayList<>(orderItems)
         );
     }
 

--- a/src/main/java/com/lxp/aplus/order/domain/OrderItem.java
+++ b/src/main/java/com/lxp/aplus/order/domain/OrderItem.java
@@ -1,15 +1,14 @@
 package com.lxp.aplus.order.domain;
 
+import com.lxp.aplus.common.domain.BaseTimeEntity;
 import com.lxp.aplus.order.application.CoursePrice;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+
 
 /**
  * OrderLine (Value Object)
@@ -38,32 +37,49 @@ import java.math.BigDecimal;
  *   Entity(OrderItem)로의 승격을 검토한다
  */
 
-@Embeddable
+@Entity
+@Table(name = "order_items")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class OrderLine {
+public class OrderItem extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long orderItemId;  // 주문 아이템 식별자
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    private Order order;
 
     @Enumerated(EnumType.STRING)
-    private ItemType itemType;
+    @Column(nullable = false)
+    private ItemType itemType; // 상품 타입
 
-    private Long itemId;
+    @Column(nullable = false)
+    private Long itemId; // 상품 아이디 (현재는 courseId)
 
     @Column(nullable = false, precision = 10, scale = 0)
     private BigDecimal price;
 
-    protected OrderLine(ItemType itemType, Long itemId, BigDecimal price) {
+    protected OrderItem(ItemType itemType, Long itemId, BigDecimal price) {
         this.itemType = itemType;
         this.itemId = itemId;
         this.price = price;
     }
 
-    // FIXME: course 네이밍 바꾸기 (course 도메인과 헷갈릴 여지 있음)
-    public static OrderLine course(Long courseId, BigDecimal price) {
-        return new OrderLine(ItemType.COURSE, courseId, price);
+    /**
+     * 연관관계 편의 메서드
+     * Order 엔티티에서 호출하여 양방향 관계를 맺어줍니다.
+     */
+    public void assignOrder(Order order) {
+        if (this.order != null) {
+            return; // 이미 할당된 경우 재할당 방지
+        }
+        this.order = order;
     }
 
-    public static OrderLine from(CoursePrice coursePrice) {
-        return new OrderLine(
+    public static OrderItem create(CoursePrice coursePrice) {
+        return new OrderItem(
                 ItemType.COURSE,
                 coursePrice.courseId(),
                 BigDecimal.valueOf(coursePrice.price()) // int -> BigDecimal

--- a/src/main/java/com/lxp/aplus/order/domain/OrderItem.java
+++ b/src/main/java/com/lxp/aplus/order/domain/OrderItem.java
@@ -43,6 +43,7 @@ import java.math.BigDecimal;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrderItem extends BaseTimeEntity {
 
+    // TODO: orderItemId -> id로 수정
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
@@ -73,6 +74,7 @@ public class OrderItem extends BaseTimeEntity {
      * Order 엔티티에서 호출하여 양방향 관계를 맺어줍니다.
      */
     public void assignOrder(Order order) {
+        // TODO: OrderItem 생성자에서 반영해주고 update 불가하게 처리해주면 안되나요?
         if (this.order != null) {
             return; // 이미 할당된 경우 재할당 방지
         }

--- a/src/main/java/com/lxp/aplus/order/domain/OrderItem.java
+++ b/src/main/java/com/lxp/aplus/order/domain/OrderItem.java
@@ -45,6 +45,7 @@ public class OrderItem extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
     private Long orderItemId;  // 주문 아이템 식별자
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/lxp/aplus/payment/application/port/out/EnrollmentCommandPort.java
+++ b/src/main/java/com/lxp/aplus/payment/application/port/out/EnrollmentCommandPort.java
@@ -1,6 +1,6 @@
 package com.lxp.aplus.payment.application.port.out;
 
-import java.util.List;
+import java.util.Map;
 
 public interface EnrollmentCommandPort {
 
@@ -8,7 +8,7 @@ public interface EnrollmentCommandPort {
      * 특정 사용자에게 구매 강좌에 대한 수강 권한을 동기적으로 부여한다.
      * TODO: 나중에 이벤트로 비동기 처리하도록 리팩터
      * @param userId 수강을 요청하는 사용자 ID
-     * @param courseIds 수강권 부여의 근거가 된 주문 ID 목록
+     * @param courseToOrderItemMap { courseId: orderItemId }
      */
-    void enrollUserInCourses(Long userId, List<Long> courseIds);
+    void enrollUserInCourses(Long userId, Map<Long, Long> courseToOrderItemMaps);
 }

--- a/src/main/java/com/lxp/aplus/payment/application/port/out/OrderCommandPort.java
+++ b/src/main/java/com/lxp/aplus/payment/application/port/out/OrderCommandPort.java
@@ -1,5 +1,6 @@
 package com.lxp.aplus.payment.application.port.out;
 
+import com.lxp.aplus.order.domain.OrderItem;
 import com.lxp.aplus.payment.application.result.OrderCreateResult;
 
 import java.math.BigDecimal;
@@ -16,4 +17,9 @@ public interface OrderCommandPort {
      * 주문 완료 (COMPLETED)
      */
     void completeOrder(String orderId, String approvedPaymentId, BigDecimal approvedAmount);
+
+    /*
+     * 주문ID로 주문 항목 조회
+     */
+    List<OrderItem> getOrderItemsOfOrder(String orderId);
 }

--- a/src/main/java/com/lxp/aplus/payment/application/usecase/PaymentCommandUseCase.java
+++ b/src/main/java/com/lxp/aplus/payment/application/usecase/PaymentCommandUseCase.java
@@ -2,6 +2,7 @@ package com.lxp.aplus.payment.application.usecase;
 
 import com.lxp.aplus.common.error.BusinessException;
 import com.lxp.aplus.common.error.code.PaymentErrorCode;
+import com.lxp.aplus.order.domain.OrderItem;
 import com.lxp.aplus.payment.application.port.out.EnrollmentCommandPort;
 import com.lxp.aplus.payment.application.port.out.OrderQueryPort;
 import com.lxp.aplus.payment.application.result.OrderCreateResult;
@@ -12,11 +13,15 @@ import com.lxp.aplus.payment.domain.Payment;
 import com.lxp.aplus.payment.domain.PaymentRepository;
 import com.lxp.aplus.payment.presentation.response.PaymentPrepareResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -68,6 +73,16 @@ public class PaymentCommandUseCase {
 
         // 6. 수강 권한 부여
         // TODO: 향후 이벤트로 처리
-        enrollmentCommandPort.enrollUserInCourses(command.userId(), courseIds);
+        List<OrderItem> orderItems = orderCommandPort.getOrderItemsOfOrder(command.orderId());
+
+        Map<Long, Long> courseToOrderItemMap = orderItems.stream()
+                        .collect(Collectors.toMap(
+                                OrderItem::getItemId,      // courseId
+                                OrderItem::getOrderItemId  // 실제 PK
+                        ));
+
+        log.debug("수강 신청 매핑 정보: {}", courseToOrderItemMap);
+
+        enrollmentCommandPort.enrollUserInCourses(command.userId(), courseToOrderItemMap);
     }
 }

--- a/src/main/java/com/lxp/aplus/payment/infrastructure/adapter/EnrollmentCommandAdapter.java
+++ b/src/main/java/com/lxp/aplus/payment/infrastructure/adapter/EnrollmentCommandAdapter.java
@@ -35,6 +35,7 @@ public class EnrollmentCommandAdapter implements EnrollmentCommandPort {
             Long courseId = entry.getKey();
             Long orderItemId = entry.getValue();
 
+            // TODO: N+1 문제 확인
             boolean isEnrolled = enrollmentRepository.existsByStudentIdAndCourseId(userId, courseId);
 
             if (!isEnrolled) {

--- a/src/main/java/com/lxp/aplus/payment/infrastructure/adapter/EnrollmentCommandAdapter.java
+++ b/src/main/java/com/lxp/aplus/payment/infrastructure/adapter/EnrollmentCommandAdapter.java
@@ -1,15 +1,17 @@
 package com.lxp.aplus.payment.infrastructure.adapter;
 
+import com.lxp.aplus.course.domain.Course;
 import com.lxp.aplus.enrollment.domain.Enrollment;
 import com.lxp.aplus.enrollment.domain.EnrollmentRepository;
+import com.lxp.aplus.order.domain.OrderItem;
 import com.lxp.aplus.payment.application.port.out.EnrollmentCommandPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * EnrollmentCommandPort의 구현체 (Adapter)
@@ -23,20 +25,23 @@ public class EnrollmentCommandAdapter implements EnrollmentCommandPort {
     private final EnrollmentRepository enrollmentRepository;
 
     @Override
-    public void enrollUserInCourses(Long userId, List<Long> courseIds) {
+    public void enrollUserInCourses(Long userId, Map<Long, Long> courseToOrderItemMap) {
 
         // 1. 중복 수강 여부 확인 -> Enrollment 생성
         // TODO: Enrollment 도메인 규칙으로 이동
         List<Enrollment> newEnrollments = new ArrayList<>();
 
-        for (Long courseId : courseIds) {
+        for (Map.Entry<Long, Long> entry : courseToOrderItemMap.entrySet()) {
+            Long courseId = entry.getKey();
+            Long orderItemId = entry.getValue();
+
             boolean isEnrolled = enrollmentRepository.existsByStudentIdAndCourseId(userId, courseId);
 
             if (!isEnrolled) {
                 Enrollment enrollment = Enrollment.create(
                         userId,
                         courseId,
-                        null
+                        orderItemId
                 );
 
                 newEnrollments.add(enrollment);

--- a/src/main/java/com/lxp/aplus/payment/infrastructure/adapter/OrderCommandAdapter.java
+++ b/src/main/java/com/lxp/aplus/payment/infrastructure/adapter/OrderCommandAdapter.java
@@ -6,9 +6,9 @@ import com.lxp.aplus.common.error.code.OrderErrorCode;
 import com.lxp.aplus.course.domain.Course;
 import com.lxp.aplus.course.domain.CourseRepository;
 import com.lxp.aplus.order.application.CoursePrice;
+import com.lxp.aplus.order.domain.OrderItem;
 import com.lxp.aplus.payment.application.result.OrderCreateResult;
 import com.lxp.aplus.order.domain.Order;
-import com.lxp.aplus.order.domain.OrderLine;
 import com.lxp.aplus.order.domain.OrderRepository;
 import com.lxp.aplus.payment.application.port.out.OrderCommandPort;
 import lombok.RequiredArgsConstructor;
@@ -32,13 +32,13 @@ public class OrderCommandAdapter implements OrderCommandPort {
         // 1. Course 가격 조회 (From Course BC)
         List<CoursePrice> coursePrices = getCoursePriceByIds(courseIds);
 
-        // 2. OrderLine 리스트 생성
-        List<OrderLine> orderLines = coursePrices.stream()
-                .map(OrderLine::from)
-                .collect(Collectors.toList());
+        // 2. OrderItem 리스트 생성
+        List<OrderItem> OrderItems = coursePrices.stream()
+                .map(OrderItem::create)
+                .toList();
 
         // 3. Order 생성 및 저장
-        Order order = Order.create(userId, orderLines);
+        Order order = Order.create(userId, OrderItems);
         orderRepository.save(order);
 
         return OrderCreateResult.of(order.getOrderId(), order.getAmount());
@@ -68,5 +68,15 @@ public class OrderCommandAdapter implements OrderCommandPort {
 
         // 2. Order 상태 변경
         order.completeWithApprovedPayment(approvedPaymentId, approvedAmount);
+    }
+
+    public List<OrderItem> getOrderItemsOfOrder(String orderId) {
+
+        // 1. Order 조회
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        // 2. Order의 OrderItem 리스트 조회
+        return order.getOrderItems();
     }
 }

--- a/src/main/java/com/lxp/aplus/payment/infrastructure/adapter/OrderQueryAdapter.java
+++ b/src/main/java/com/lxp/aplus/payment/infrastructure/adapter/OrderQueryAdapter.java
@@ -3,7 +3,7 @@ package com.lxp.aplus.payment.infrastructure.adapter;
 import com.lxp.aplus.common.error.BusinessException;
 import com.lxp.aplus.common.error.code.OrderErrorCode;
 import com.lxp.aplus.order.domain.Order;
-import com.lxp.aplus.order.domain.OrderLine;
+import com.lxp.aplus.order.domain.OrderItem;
 import com.lxp.aplus.order.domain.OrderRepository;
 import com.lxp.aplus.payment.application.port.out.OrderQueryPort;
 import lombok.RequiredArgsConstructor;
@@ -33,8 +33,8 @@ public class OrderQueryAdapter implements OrderQueryPort {
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
 
         // 2. OrderLine 목록에서 courseId 추출 및 반환
-        return order.getOrderLines().stream()
-                .map(OrderLine::getItemId)
+        return order.getOrderItems().stream()
+                .map(OrderItem::getItemId)
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/lxp/aplus/payment/presentation/request/PaymentPrepareRequest.java
+++ b/src/main/java/com/lxp/aplus/payment/presentation/request/PaymentPrepareRequest.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public record PaymentPrepareRequest(
         @NotNull(message = "items는 필수입니다.")
-        @Size(min = 1, max = 1, message = "현재는 1개의 item만 가능합니다.(v2025-12-11)") // TODO: 묶음 결제(장바구니) 기능 추가 시 max 변경
+        @Size(min = 1, message = "최소 1개 이상의 상품을 선택해야합니다.")
         @Valid
         List<Item> items
 ) {

--- a/src/main/resources/db/migration/V11__create_order_items.sql
+++ b/src/main/resources/db/migration/V11__create_order_items.sql
@@ -1,0 +1,14 @@
+create table if not exists order_items
+(
+    id         bigint auto_increment primary key, -- Java: orderItemId
+    order_id   varchar(255)   not null,           -- FK to orders.id
+    item_type  varchar(50)    not null,           -- Enum (COURSE 등)
+    item_id    bigint         not null,           -- CourseId 등
+    price      decimal(10, 0) not null,           -- precision 10, scale 0
+    created_at datetime(6)    not null,
+    updated_at datetime(6)    not null,
+
+    constraint fk_order_items_order_id
+    foreign key (order_id) references orders (id)
+    on delete cascade
+);


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ✨ 요약

- OrderLine -> OrderItem Entity로 승격
- 수강 신청 로직에서 orderItemId와 함께 enrollment 데이터가 생성되도록 수정
- 결제 준비 API의 request dto에서 결제할 수 있는 강좌를 1개로 제한했던 것에서 max 옵션 삭제 => 묶음 결제 가능

## 📝 작업 내용

## 💭 주의 사항

- Enrollment와 초초초 강결합 이슈 🚨🚨🚨🚨🚨

## 💡 리뷰 포인트

## ✅ 테스트
- [x] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [x] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)

### Payment 

- status : PENDING -> APPROVED 상태 변경 확인
- orderId : 저장 확인
- amount : 여러 강좌의 합계와 같은지 확인

<img width="940" height="373" alt="image" src="https://github.com/user-attachments/assets/5ef23787-4da0-44ad-acca-cec9a17e83f0" />

### Order

- orderId : payments의 order_id와 같은지 확인
- order_status : PENDING -> COMPLETED 확인
- amount : payments의 amount와 같은지 확인
- approved_id : payments의 id와 같은지 확인

<img width="906" height="346" alt="image" src="https://github.com/user-attachments/assets/9f341d29-3f19-48eb-b40c-9ace9510d4e1" />

### OrderItem

- item_id : course_id와 같은지 확인
- order_id : order.id와 같은지 확인
- 생성된 개수가 API 요청 본문의 courseId 개수와 일치하는지 확인

<img width="1096" height="341" alt="image" src="https://github.com/user-attachments/assets/672d9630-266d-4ada-b553-54aee6f80ad5" />

### Enrollment

- order_item_id : OrderItem.id와 같은지 확인 + 개수 일치하는지 확인
<img width="950" height="246" alt="image" src="https://github.com/user-attachments/assets/efaa2016-922b-40fb-a3c5-a1575d481c47" />

### API 테스트
1. 강좌 3개 생성

2. 결제 준비 API 요청

<img width="878" height="346" alt="image" src="https://github.com/user-attachments/assets/4b2c61df-6554-4640-ba10-a3f33f0bac73" />

3. 결제 완료 API 요청

<img width="909" height="236" alt="image" src="https://github.com/user-attachments/assets/c15b56ef-8a38-4c2e-9e9e-87fec088c18e" />


#165 