### PR TITLE
[REFACTOR] Course 도메인 생성/조회 리팩토링

### DIFF
--- a/src/main/java/com/lxp/aplus/common/error/code/LectureResourceErrorCode.java
+++ b/src/main/java/com/lxp/aplus/common/error/code/LectureResourceErrorCode.java
@@ -15,7 +15,9 @@ public enum LectureResourceErrorCode implements ErrorCode {
     LECTURE_RESOURCE_NOT_EXIST(HttpStatus.NOT_FOUND, "ER005", "존재하지 않는 리소스 입니다."),
     STORAGE_CLIENT_INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "ER006", "스토리지 서버 오류입니다."),
     LECTURE_RESOURCE_VIDEO_DURATION_NOT_FOUND(HttpStatus.NOT_FOUND, "ER007", "동영상 리소스는 duration 값이 필수 입니다."),
-    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "ER008", "파일 사이즈 용량을 초과했습니다.")
+    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "ER008", "파일 사이즈 용량을 초과했습니다."),
+    LECTURE_RESOURCE_NOT_FOUND(HttpStatus.BAD_REQUEST, "ER009", "key에 해당하는 파일을 찾을 수 없습니다."),
+    LECTURE_RESOURCE_ALREADY_USE(HttpStatus.BAD_REQUEST, "ER010", "이미 다른 강의에서 사용하고 있는 리소스입니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/lxp/aplus/course/application/command/CourseCreateCommand.java
+++ b/src/main/java/com/lxp/aplus/course/application/command/CourseCreateCommand.java
@@ -13,6 +13,7 @@ public record CourseCreateCommand(
         int price,
         String thumbnailUrl,
         MultipartFile thumbnailFile,
-        CourseLevel courseLevel
+        CourseLevel courseLevel,
+        String thumbnailResourceKey
 ) {
 }

--- a/src/main/java/com/lxp/aplus/course/application/command/CreateLectureCommand.java
+++ b/src/main/java/com/lxp/aplus/course/application/command/CreateLectureCommand.java
@@ -8,6 +8,6 @@ public record CreateLectureCommand(
         Integer totalDurationSeconds,
         boolean isPreview,
         int orderIndex,
-        CreateLectureResourceCommand resource
+        String resourceKey
 ) {
 }

--- a/src/main/java/com/lxp/aplus/course/application/result/CourseDetailResult.java
+++ b/src/main/java/com/lxp/aplus/course/application/result/CourseDetailResult.java
@@ -18,7 +18,7 @@ public record CourseDetailResult(
         int price,
         CourseStatus status,
         CourseLevel level,
-        String thumbnailUrl,
+        String thumbnailResourceKey,
         InstructorResult instructor,
         boolean isPurchased,
         int studentCount,
@@ -35,7 +35,7 @@ public record CourseDetailResult(
                 .price(course.getPrice())
                 .status(course.getCourseStatus())
                 .level(course.getCourseLevel())
-                .thumbnailUrl(course.getThumbnailUrl())
+                .thumbnailResourceKey(course.getThumbnailResourceKey())
                 .instructor(instructor)
                 .isPurchased(isPurchased)
                 .studentCount(studentCount)

--- a/src/main/java/com/lxp/aplus/course/application/result/CourseResult.java
+++ b/src/main/java/com/lxp/aplus/course/application/result/CourseResult.java
@@ -15,7 +15,7 @@ public record CourseResult(
         String summary,
         String instructorName,
         List<String> categories,
-        String thumbnailUrl,
+        String thumbnailResourceKey,
         CourseStatus status,
         int price,
         CourseLevel level,
@@ -30,7 +30,7 @@ public record CourseResult(
                 .summary(course.getSummary())
                 .instructorName(instructorName)
                 .categories(categoryNames)
-                .thumbnailUrl(course.getThumbnailUrl())
+                .thumbnailResourceKey(course.getThumbnailResourceKey())
                 .status(course.getCourseStatus())
                 .price(course.getPrice())
                 .level(course.getCourseLevel())

--- a/src/main/java/com/lxp/aplus/course/application/result/LectureResourceResult.java
+++ b/src/main/java/com/lxp/aplus/course/application/result/LectureResourceResult.java
@@ -7,6 +7,6 @@ import lombok.Builder;
 public record LectureResourceResult(
         ResourceType resourceType,
         boolean isDownloadable,
-        String fileUrl
+        String fileKey
 ) {
 }

--- a/src/main/java/com/lxp/aplus/course/application/result/LectureResult.java
+++ b/src/main/java/com/lxp/aplus/course/application/result/LectureResult.java
@@ -5,6 +5,7 @@ import com.lxp.aplus.course.domain.LectureResource;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Builder
 public record LectureResult (
@@ -18,7 +19,15 @@ public record LectureResult (
         LectureResourceResult resource
 ) {
     public static LectureResult from(Lecture lecture) {
-        LectureResource lectureResource = lecture.getLectureResources().get(0);
+        LectureResourceResult resourceResult = Optional.ofNullable(lecture.getLectureResources())
+                .filter(list -> !list.isEmpty())
+                .map(list -> list.get(0))
+                .map(res -> LectureResourceResult.builder()
+                        .resourceType(res.getResourceType())
+                        .isDownloadable(res.isDownloadable())
+                        .fileKey(res.getFileKey())
+                        .build())
+                .orElse(null);
 
         return LectureResult.builder()
                 .id(lecture.getId())
@@ -28,17 +37,7 @@ public record LectureResult (
                 .orderIndex(lecture.getOrderIndex())
                 .createdAt(lecture.getCreatedAt())
                 .updatedAt(lecture.getUpdatedAt())
-                .resource(new LectureResourceResult(lecture.getLectureResources().get(0).getResourceType(),
-                        lecture.getLectureResources().get(0).isDownloadable(),
-                        lecture.getLectureResources().get(0).getFileUrl()
-                ))
-                .resource(
-                        LectureResourceResult.builder()
-                                .resourceType(lectureResource.getResourceType())
-                                .isDownloadable(lectureResource.isDownloadable())
-                                .fileUrl(lectureResource.getFileUrl())
-                                .build()
-                )
+                .resource(resourceResult)
                 .build();
     }
 }

--- a/src/main/java/com/lxp/aplus/course/application/usecase/CourseCommandUseCase.java
+++ b/src/main/java/com/lxp/aplus/course/application/usecase/CourseCommandUseCase.java
@@ -18,11 +18,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CourseCommandUseCase {
     private final CourseRepository courseRepository;
-    private final FileUploader fileUploader;
 
     public CourseUpsertResult createCourse(Long instructorId, CourseCreateCommand command) {
-        String thumbnailUrl = fileUploader.upload(command.thumbnailFile());
-        Course course = Course.createDraftCourse(instructorId, thumbnailUrl, command);
+        Course course = Course.createDraftCourse(instructorId, command);
         Course savedCourse = courseRepository.save(course);
 
         return CourseUpsertResult.from(savedCourse);

--- a/src/main/java/com/lxp/aplus/course/application/usecase/LectureCommandUseCase.java
+++ b/src/main/java/com/lxp/aplus/course/application/usecase/LectureCommandUseCase.java
@@ -2,6 +2,7 @@ package com.lxp.aplus.course.application.usecase;
 
 import com.lxp.aplus.common.error.BusinessException;
 import com.lxp.aplus.common.error.code.CourseErrorCode;
+import com.lxp.aplus.common.error.code.LectureResourceErrorCode;
 import com.lxp.aplus.course.application.command.CreateLectureCommand;
 import com.lxp.aplus.course.application.command.UpdateLectureCommand;
 import com.lxp.aplus.course.application.file.FileValidator;
@@ -20,29 +21,29 @@ import org.springframework.stereotype.Service;
 public class LectureCommandUseCase {
 
     private final CourseRepository courseRepository;
+    private final LectureResourceRepository lectureResourceRepository;
     private final FileValidator fileValidator;
     private final LectureFileStore lectureFileStore;
 
-    public LectureResult createLecture(Long courseId, Long sectionId, CreateLectureCommand command) {
+    public LectureResult createLecture(Long courseId, Long sectionId, Long instructorId, CreateLectureCommand command) {
 
         Course course = courseRepository.findById(courseId)
                 .orElseThrow(() -> new BusinessException(CourseErrorCode.COURSE_NOT_FOUND));
 
-        UploadFile file = command.resource().uploadFile();
+        course.validateOwner(instructorId);
 
-        fileValidator.validateRequired(file);
-        StoredFileInfo storedFile = lectureFileStore.storeLectureResourceFile(courseId, file);
+        LectureResourceV2 lectureResourceV2 = lectureResourceRepository.findByKey(command.resourceKey())
+                .orElseThrow(() -> new BusinessException(LectureResourceErrorCode.LECTURE_RESOURCE_NOT_FOUND));
+        if (lectureResourceV2.getLecture() != null) {
+            throw new BusinessException(LectureResourceErrorCode.LECTURE_RESOURCE_ALREADY_USE);
+        }
 
         Lecture lecture = course.createLecture(
                 sectionId,
                 command.title(),
-                command.totalDurationSeconds(),
                 command.isPreview(),
-                command.orderIndex(),
-                command.resource().isDownloadable(),
-                storedFile.fileKey(),
-                storedFile.fileUrl(),
-                file.originalFileName()
+                lectureResourceV2,
+                command.orderIndex()
         );
 
         courseRepository.flush();

--- a/src/main/java/com/lxp/aplus/course/domain/Course.java
+++ b/src/main/java/com/lxp/aplus/course/domain/Course.java
@@ -54,8 +54,8 @@ public class Course extends BaseAggregateRoot {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String description;
 
-    @Column(nullable = false)
-    private String thumbnailUrl;
+    @Column(name = "thumbnail_key")
+    private String thumbnailResourceKey;
 
     @Column(nullable = false)
     private int price;
@@ -73,14 +73,14 @@ public class Course extends BaseAggregateRoot {
     @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Section> sections = new ArrayList<>();
 
-    public static Course createDraftCourse(Long instructorId, String thumbnailUrl, CourseCreateCommand command) {
+    public static Course createDraftCourse(Long instructorId, CourseCreateCommand command) {
         return Course.builder()
                 .instructorId(instructorId)
                 .categoryId(command.categoryId())
                 .title(command.title())
                 .summary(command.summary())
                 .description(command.description())
-                .thumbnailUrl(thumbnailUrl)
+                .thumbnailResourceKey(command.thumbnailResourceKey())
                 .price(command.price())
                 .courseLevel(command.courseLevel())
                 .build();
@@ -116,7 +116,7 @@ public class Course extends BaseAggregateRoot {
             if (command.thumbnailUrl().isBlank()) {
                 throw new BusinessException(GlobalErrorCode.INVALID_ARGUMENT);
             }
-            this.thumbnailUrl = command.thumbnailUrl();
+            this.thumbnailResourceKey = command.thumbnailUrl();
         }
 
         if (command.price() != null) {
@@ -192,13 +192,13 @@ public class Course extends BaseAggregateRoot {
         }
     }
 
-    public Lecture createLecture(Long sectionId, String title, Integer totalDurationSeconds, boolean isPreview, int orderIndex, boolean isDownloadable, String fileKey, String fileUrl, String originFileName) {
+    public Lecture createLecture(Long sectionId, String title, boolean isPreview, LectureResourceV2 resource, int orderIndex) {
             Section section = sections.stream()
                 .filter(s -> s.getId().equals(sectionId))
                 .findFirst()
                 .orElseThrow(() -> new BusinessException(SectionErrorCode.SECTION_NOT_FOUND));
 
-        return section.addLecture(title, totalDurationSeconds, isPreview, orderIndex, isDownloadable, fileKey, fileUrl, originFileName);
+        return section.addLecture(title, isPreview, resource, orderIndex);
     }
 
     public Lecture updateLectureMeta(Long lectureId, String title, Integer totalDurationSeconds, boolean isPreview, int orderIndex) {

--- a/src/main/java/com/lxp/aplus/course/domain/Lecture.java
+++ b/src/main/java/com/lxp/aplus/course/domain/Lecture.java
@@ -28,7 +28,7 @@ public class Lecture extends BaseTimeEntity {
 
     @BatchSize(size = 10)
     @OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<LectureResource> lectureResources = new ArrayList<>();
+    private List<LectureResourceV2> lectureResources = new ArrayList<>();
 
     @Column(name = "total_duration_seconds")
     private Integer totalDurationSeconds;
@@ -43,40 +43,44 @@ public class Lecture extends BaseTimeEntity {
     @Min(1)
     private int orderIndex;
 
-    private Lecture(Section section, String title, Integer totalDurationSeconds, boolean isPreview, int orderIndex) {
+    private Lecture(Section section, String title, LectureResourceV2 resource, boolean isPreview, int orderIndex) {
         this.section = section;
         this.title = title;
-        this.totalDurationSeconds = totalDurationSeconds;
         this.isPreview = isPreview;
         this.orderIndex = orderIndex;
-        this.lectureResources = new ArrayList<>();
+        this.lectureResources.add(resource);
+        this.totalDurationSeconds = resource.getVideoDuration().duration();
     }
 
-    public static Lecture create(Section section, String title, Integer totalDurationSeconds, boolean isPreview, int orderIndex, boolean isDownloadable, String fileKey, String fileUrl, String originFileName) {
-        Lecture lecture = new Lecture(section, title, totalDurationSeconds, isPreview, orderIndex);
-        LectureResource resource = LectureResource.create(lecture, isDownloadable, fileKey, fileUrl,  originFileName);
-        lecture.lectureResources.add(resource);
+    public static Lecture create(Section section, String title, LectureResourceV2 resource, boolean isPreview, int orderIndex) {
+        Lecture lecture = new Lecture(section, title, resource, isPreview, orderIndex);
+        lecture.addResource(resource);
 
         return lecture;
     }
 
-    public void update(String title, Integer totalDurationSeconds, boolean isPreview, int orderIndex) {
-        this.title = title;
-        this.totalDurationSeconds = totalDurationSeconds;
-        this.isPreview = isPreview;
-        this.orderIndex = orderIndex;
-    }
-
-    public void update(String title, Integer totalDurationSeconds, boolean isPreview, int orderIndex, boolean isDownloadable, String fileKey, String fileUrl, String originFileName) {
-        this.title = title;
-        this.totalDurationSeconds = totalDurationSeconds;
-        this.isPreview = isPreview;
-        this.orderIndex = orderIndex;
-
-        this.lectureResources.clear();
-        LectureResource resource = LectureResource.create(this, isDownloadable, fileKey, fileUrl, originFileName);
+    public void addResource(LectureResourceV2 resource) {
         this.lectureResources.add(resource);
+        resource.assignToLecture(this);
     }
+
+    public void update(String title, boolean isPreview, int orderIndex) {
+        this.title = title;
+        this.isPreview = isPreview;
+        this.orderIndex = orderIndex;
+    }
+
+    // TODO: 업데이트 로직 구현 필요 
+//    public void update(String title, Integer totalDurationSeconds, boolean isPreview, int orderIndex, boolean isDownloadable, String fileKey, String fileUrl, String originFileName) {
+//        this.title = title;
+//        this.totalDurationSeconds = totalDurationSeconds;
+//        this.isPreview = isPreview;
+//        this.orderIndex = orderIndex;
+//
+//        this.lectureResources.clear();
+//        LectureResource resource = LectureResource.create(this, isDownloadable, fileKey, fileUrl, originFileName);
+//        this.lectureResources.add(resource);
+//    }
 
     public void validateHasResource() {
         if (this.lectureResources == null || this.lectureResources.isEmpty()) {

--- a/src/main/java/com/lxp/aplus/course/domain/LectureResourceRepository.java
+++ b/src/main/java/com/lxp/aplus/course/domain/LectureResourceRepository.java
@@ -1,5 +1,8 @@
 package com.lxp.aplus.course.domain;
 
+import java.util.Optional;
+
 public interface LectureResourceRepository {
     LectureResourceV2 save(LectureResourceV2 lectureResource);
+    Optional<LectureResourceV2> findByKey(String key);
 }

--- a/src/main/java/com/lxp/aplus/course/domain/LectureResourceV2.java
+++ b/src/main/java/com/lxp/aplus/course/domain/LectureResourceV2.java
@@ -17,6 +17,10 @@ public class LectureResourceV2 extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lecture_id")
+    private Lecture lecture;
+
     @Column(name = "original_file_name", nullable = false)
     private String originalFileName;
 
@@ -68,5 +72,9 @@ public class LectureResourceV2 extends BaseTimeEntity {
                 videoDuration,
                 isDownloadable
         );
+    }
+
+    void assignToLecture(Lecture lecture) {
+        this.lecture = lecture;
     }
 }

--- a/src/main/java/com/lxp/aplus/course/domain/Section.java
+++ b/src/main/java/com/lxp/aplus/course/domain/Section.java
@@ -52,8 +52,8 @@ public class Section extends BaseTimeEntity {
     @OneToMany(mappedBy = "section", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Lecture> lectures = new ArrayList<>();
 
-    public Lecture addLecture(String title, Integer totalDurationSeconds, boolean isPreview, int orderIndex, boolean isDownloadable, String fileKey, String fileUrl, String originFileName) {
-        Lecture lecture = Lecture.create(this, title, totalDurationSeconds, isPreview, orderIndex, isDownloadable, fileKey, fileUrl, originFileName);
+    public Lecture addLecture(String title, boolean isPreview, LectureResourceV2 resource, int orderIndex) {
+        Lecture lecture = Lecture.create(this, title, resource, isPreview, orderIndex);
         this.lectures.add(lecture);
         return lecture;
     }
@@ -63,7 +63,7 @@ public class Section extends BaseTimeEntity {
                 .filter(l -> l.getId().equals(lectureId))
                 .findFirst()
                 .orElseThrow(() -> new BusinessException(LectureErrorCode.LECTURE_NOT_FOUND));
-        lecture.update(title, totalDurationSeconds, isPreview, orderIndex);
+        lecture.update(title, isPreview, orderIndex);
         return lecture;
     }
 
@@ -72,7 +72,8 @@ public class Section extends BaseTimeEntity {
                 .filter(l -> l.getId().equals(lectureId))
                 .findFirst()
                 .orElseThrow(() -> new BusinessException(LectureErrorCode.LECTURE_NOT_FOUND));
-        lecture.update(title, totalDurationSeconds, isPreview, orderIndex, isDownloadable, fileKey, fileUrl, originFileName);
+        // TODO: 리소스 업데이트
+//        lecture.update(title, totalDurationSeconds, isPreview, orderIndex, isDownloadable, fileKey, fileUrl, originFileName);
         return lecture;
     }
 

--- a/src/main/java/com/lxp/aplus/course/infrastructure/persistence/LectureResourceJpaRepository.java
+++ b/src/main/java/com/lxp/aplus/course/infrastructure/persistence/LectureResourceJpaRepository.java
@@ -3,5 +3,9 @@ package com.lxp.aplus.course.infrastructure.persistence;
 import com.lxp.aplus.course.domain.LectureResourceV2;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface LectureResourceJpaRepository extends JpaRepository<LectureResourceV2, Long> {
+    Optional<LectureResourceV2> findByFileKey(String fileKey);
+
 }

--- a/src/main/java/com/lxp/aplus/course/infrastructure/persistence/LectureResourceRepositoryImpl.java
+++ b/src/main/java/com/lxp/aplus/course/infrastructure/persistence/LectureResourceRepositoryImpl.java
@@ -5,6 +5,8 @@ import com.lxp.aplus.course.domain.LectureResourceV2;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class LectureResourceRepositoryImpl implements LectureResourceRepository {
@@ -13,5 +15,10 @@ public class LectureResourceRepositoryImpl implements LectureResourceRepository 
     @Override
     public LectureResourceV2 save(LectureResourceV2 lectureResource) {
         return lectureResourceJpaRepository.save(lectureResource);
+    }
+
+    @Override
+    public Optional<LectureResourceV2> findByKey(String key) {
+        return lectureResourceJpaRepository.findByFileKey(key);
     }
 }

--- a/src/main/java/com/lxp/aplus/course/presentation/controller/CourseController.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/controller/CourseController.java
@@ -44,13 +44,12 @@ public class CourseController {
     private final CourseQueryUseCase courseQueryUseCase;
 
     @InstructorOnly
-    @PostMapping(value = "/api/instructor/courses", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(value = "/api/instructor/courses")
     public ResponseEntity<ResultResponse<CourseUpsertResponse>> createCourse(
             @Authenticated Long instructorId,
-            @RequestPart("request") @Valid CourseCreateRequest request,
-            @RequestPart("thumbnail") MultipartFile thumbnail
+            @RequestBody @Valid CourseCreateRequest request
     ) {
-        CourseUpsertResult result = courseCommandUseCase.createCourse(instructorId, request.toCommand(thumbnail));
+        CourseUpsertResult result = courseCommandUseCase.createCourse(instructorId, request.toCommand());
 
         return ResponseEntity
                 .status(CourseResultCode.COURSE_REGISTER_SUCCESS.getStatus())

--- a/src/main/java/com/lxp/aplus/course/presentation/controller/LectureController.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/controller/LectureController.java
@@ -32,24 +32,19 @@ public class LectureController {
 
     /** 강의 생성 **/
     @InstructorOnly
-    @PostMapping(
-            value = "/instructor/courses/{courseId}/sections/{sectionId}/lectures",
-            consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ResultResponse<LectureResponse>> createLecture (@Valid @PathVariable Long courseId,
-                                                                          @Authenticated Long instructorId,
-                                                                          @PathVariable Long sectionId,
-                                                                          @RequestPart("lecture") LectureCreateRequest request,
-                                                                          @RequestPart("multiFile") MultipartFile file) throws IOException {
+    @PostMapping(value = "/instructor/courses/{courseId}/sections/{sectionId}/lectures")
+    public ResponseEntity<ResultResponse<LectureResponse>> createLecture (
+            @Authenticated Long instructorId,
+            @PathVariable Long courseId,
+            @PathVariable Long sectionId,
+            @Valid @RequestBody LectureCreateRequest request
+    ) {
+        CreateLectureCommand command = request.toCommand();
 
-        UploadFile uploadFile = UploadFile.from(file);
-
-        CreateLectureCommand command = request.toCommand(uploadFile);
-
-        LectureResult result = lectureCommandUseCase.createLecture(courseId, sectionId, command);
+        LectureResult result = lectureCommandUseCase.createLecture(courseId, sectionId, instructorId, command);
 
         return ResponseEntity
                 .status(LectureResultCode.LECTURE_REGISTER_SUCCESS.getStatus())
-
                 .body(ResultResponse.of(
                         LectureResultCode.LECTURE_REGISTER_SUCCESS,
                         LectureResponse.from(result)));

--- a/src/main/java/com/lxp/aplus/course/presentation/request/CourseCreateRequest.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/request/CourseCreateRequest.java
@@ -5,7 +5,6 @@ import com.lxp.aplus.course.domain.CourseLevel;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import org.springframework.web.multipart.MultipartFile;
 
 public record CourseCreateRequest(@NotBlank(message = "제목은 필수입니다.") String title,
                                   @NotNull(message = "카테고리는 필수입니다.") Long categoryId,
@@ -14,7 +13,7 @@ public record CourseCreateRequest(@NotBlank(message = "제목은 필수입니다
                                   @NotNull(message = "가격은 필수입니다.") @Min(value = 0, message = "가격은 0원 이상이어야 합니다.") int price,
                                   @NotNull(message = "난이도는 필수입니다.") CourseLevel courseLevel
 ) {
-    public CourseCreateCommand toCommand(MultipartFile thumbnailFile) {
+    public CourseCreateCommand toCommand() {
         return CourseCreateCommand.builder()
                 .title(this.title)
                 .summary(this.summary)
@@ -22,7 +21,7 @@ public record CourseCreateRequest(@NotBlank(message = "제목은 필수입니다
                 .categoryId(this.categoryId)
                 .courseLevel(this.courseLevel)
                 .price(this.price)
-                .thumbnailFile(thumbnailFile)
+                .thumbnailFile(null) // TODO: 썸네일 리소스 key 발급 로직 필요
                 .build();
     }
 }

--- a/src/main/java/com/lxp/aplus/course/presentation/request/LectureCreateRequest.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/request/LectureCreateRequest.java
@@ -10,28 +10,21 @@ public record LectureCreateRequest(
         @NotNull(message = "제목은 필수입니다.")
         String title,
 
-        Integer totalDurationSeconds,
-
-        boolean isPreview,
+        @NotNull(message = "미리보기 여부는 필수 값입니다.")
+        Boolean isPreview,
 
         @Min(value = 1, message = "순서 인덱스는 1 이상이어야 합니다.")
         int orderIndex,
 
-        @NotNull(message = "강의 자료는 필수입니다.")
-        LectureResourceRequest resource
+        @NotNull(message = "리소스 키는 필수 입니다.")
+        String resourceKey
 ) {
-    public CreateLectureCommand toCommand(UploadFile uploadFile) {
+    public CreateLectureCommand toCommand() {
         return CreateLectureCommand.builder()
                 .title(this.title)
-                .totalDurationSeconds(this.totalDurationSeconds)
                 .isPreview(this.isPreview)
                 .orderIndex(this.orderIndex)
-                .resource(
-                        CreateLectureResourceCommand.builder()
-                                .isDownloadable(this.resource.isDownloadable())
-                                .uploadFile(uploadFile)
-                                .build()
-                )
+                .resourceKey(this.resourceKey)
                 .build();
     }
 }

--- a/src/main/java/com/lxp/aplus/course/presentation/response/CourseDetailResponse.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/response/CourseDetailResponse.java
@@ -18,7 +18,7 @@ public record CourseDetailResponse(
         int price,
         CourseStatus status,
         CourseLevel level,
-        String thumbnailUrl,
+        String thumbnailResourceKey,
         InstructorResponse instructor,
         boolean isPurchased,
         int studentCount,
@@ -35,7 +35,7 @@ public record CourseDetailResponse(
                 .price(result.price())
                 .status(result.status())
                 .level(result.level())
-                .thumbnailUrl(result.thumbnailUrl())
+                .thumbnailResourceKey(result.thumbnailResourceKey())
                 .instructor(InstructorResponse.from(result.instructor()))
                 .isPurchased(result.isPurchased())
                 .studentCount(result.studentCount())

--- a/src/main/java/com/lxp/aplus/course/presentation/response/CourseResponse.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/response/CourseResponse.java
@@ -15,7 +15,7 @@ public record CourseResponse(
         String summary,
         String instructorName,
         List<String> categories,
-        String thumbnailUrl,
+        String thumbnailResourceKey,
         CourseStatus status,
         int price,
         CourseLevel level,
@@ -30,7 +30,7 @@ public record CourseResponse(
                 .summary(result.summary())
                 .instructorName(result.instructorName())
                 .categories(result.categories())
-                .thumbnailUrl(result.thumbnailUrl())
+                .thumbnailResourceKey(result.thumbnailResourceKey())
                 .status(result.status())
                 .price(result.price())
                 .level(result.level())

--- a/src/main/java/com/lxp/aplus/course/presentation/response/LectureResourceResponse.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/response/LectureResourceResponse.java
@@ -1,6 +1,7 @@
 package com.lxp.aplus.course.presentation.response;
 
 import com.lxp.aplus.course.domain.LectureResource;
+import com.lxp.aplus.course.domain.LectureResourceV2;
 import com.lxp.aplus.course.domain.ResourceType;
 import lombok.Builder;
 
@@ -8,12 +9,12 @@ import lombok.Builder;
 public record LectureResourceResponse(
         ResourceType resourceType,
         boolean isDownloadable,
-        String fileUrl
+        String fileKey
 ) {
-    public static LectureResourceResponse from(LectureResource resource) {
+    public static LectureResourceResponse from(LectureResourceV2 resource) {
         return LectureResourceResponse.builder()
                 .resourceType(resource.getResourceType())
-                .fileUrl(resource.getFileUrl())
+                .fileKey(resource.getFileKey())
                 .isDownloadable(resource.isDownloadable())
                 .build();
     }

--- a/src/main/java/com/lxp/aplus/course/presentation/response/LectureResponse.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/response/LectureResponse.java
@@ -50,7 +50,7 @@ public record LectureResponse(
                         LectureResourceResponse.builder()
                                 .resourceType(result.resource().resourceType())
                                 .isDownloadable(result.resource().isDownloadable())
-                                .fileUrl(result.resource().fileUrl())
+                                .fileKey(result.resource().fileKey())
                                 .build()
                 )
                 .build();

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -32,3 +32,4 @@ minio:
   endpoint: "http://${MINIO_HOST}:${MINIO_PORT}"
   access-key: ${MINIO_ROOT_USER}
   secret-key: ${MINIO_ROOT_PASSWORD}
+  resource_expire_seconds: 120

--- a/src/main/resources/db/migration/V12__reflect_lecture_resource_changes_in_course.sql
+++ b/src/main/resources/db/migration/V12__reflect_lecture_resource_changes_in_course.sql
@@ -1,0 +1,25 @@
+-- Course 테이블의 thumbnail_url을 thumbnail_key로 변경
+ALTER TABLE courses
+    CHANGE COLUMN thumbnail_url thumbnail_key VARCHAR(255) NULL;
+
+-- lecture의 lecture_resources 제약 조건 삭제
+ALTER TABLE lecture_resources
+DROP FOREIGN KEY FKa42txpoawbrkifkn7lamleugw;
+
+ALTER TABLE lecture_resources
+DROP INDEX FKa42txpoawbrkifkn7lamleugw;
+
+-- lecture_resources_v2에 lecture_id 추가
+ALTER TABLE lecture_resources_v2
+    ADD COLUMN lecture_id BIGINT NULL;
+
+ALTER TABLE lecture_resources_v2
+    ADD CONSTRAINT fk_lecture_resources_v2_lecture
+        FOREIGN KEY (lecture_id) REFERENCES lectures(id);
+
+CREATE INDEX idx_lecture_resources_v2_lecture_id
+    ON lecture_resources_v2(lecture_id);
+
+--
+ALTER TABLE enrollments
+    MODIFY COLUMN order_item_id BIGINT NULL;


### PR DESCRIPTION
## ✨ 요약
- 강의 생성이 resourceKey 기반으로 변경되고 LectureResourceV2를 사용합니다
- 코스 썸네일이 URL 대신 thumbnailResourceKey로 전환됩니다.
- 강의/코스 생성 API가 multipart에서 JSON 요청으로 변경했습니다.
- lecture_resource 조회시 lecture_resources_v2를 기준으로 응답됩니다.

## 📝 작업 내용
- CreateLectureCommand/요청 DTO가 resourceKey를 받도록 개편했습니다. 
- 강의 생성 시 resourceKey로 리소스를 조회하고 중복 사용을 방지합니다
- Lecture가 LectureResourceV2를 소유하고 totalDurationSeconds를 리소스 기반으로 계산합니다.
- 응답 모델의 fileUrl을 fileKey로 치환하고 코스 결과에 thumbnailResourceKey를 노출합니다.
- LectureResourceRepository에 findByKey를 추가하고 JPA 쿼리를 연결했습니다.
- 마이그레이션에서 기존 FK 제거, lecture_resources_v2.lecture_id 추가, thumbnail_key 컬럼 변경을 적용했습니다.

## 💭 주의 사항
- 작업하다 보니 feature 보다 refactoring 이 맞는 것 같습니다 (기능은 그대로, 개선만 발생) merge 커밋은 refactor로 하겠습니다!

## 💡 리뷰 포인트
- Course, Lecture, LectureResourceV2 위주로 자세히 봐주시면 될 듯 합니다!
- update, delete 로직은 추후 다른 브랜치에서 작업 후 pr 요청드리겠습니다! 

## 추후 작업
- Course BC update/delete
- Thumbnail presigned url upload 
- presigned url GET 획득 API 

## ✅ 테스트
- [ ] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [ ] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)

closed #120
closed #121 