### PR TITLE
fix(review):  프로젝션 응답 값 타입 매핑 오류 해결

### DIFF
--- a/src/main/java/com/lxp/aplus/review/infrastructure/persistence/CustomReviewRepositoryImpl.java
+++ b/src/main/java/com/lxp/aplus/review/infrastructure/persistence/CustomReviewRepositoryImpl.java
@@ -19,7 +19,7 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
                 .select(Projections.constructor(ReviewSummary.class,
                         reviews.courseId,
                         reviews.rating.avg(),
-                        reviews.id.count()
+                        reviews.id.count().intValue()
                 ))
                 .from(reviews)
                 .where(reviews.courseId.in(courseIds))


### PR DESCRIPTION
## ✨ 요약
프로젝션을 사용한 DTO매핑시 타입 불일치 오류 발생

## 📝 작업 내용
count()는 Long 값을 반환하는데 DTO는 int형을 받고 있어서 발생한 문제.
값을 받을때 intValue()를 사용해서 해결

## 💭 주의 사항

## 💡 리뷰 포인트

## ✅ 테스트
- [ ] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [ ] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
