### PR TITLE
[FIX] lecture record -> class 변경에 따른 메소드명 불일치 이슈

### DIFF
--- a/src/main/java/com/lxp/aplus/course/domain/Lecture.java
+++ b/src/main/java/com/lxp/aplus/course/domain/Lecture.java
@@ -49,7 +49,7 @@ public class Lecture extends BaseTimeEntity {
         this.isPreview = isPreview;
         this.orderIndex = orderIndex;
         this.lectureResources.add(resource);
-        this.totalDurationSeconds = resource.getVideoDuration().duration();
+        this.totalDurationSeconds = resource.getVideoDuration().getDuration();
     }
 
     public static Lecture create(Section section, String title, LectureResourceV2 resource, boolean isPreview, int orderIndex) {


### PR DESCRIPTION
## 📝 작업 내용
- lecture 의 duration이 record 에서 class 로 변경되면서 메소드명 불일치 에러 수정
