### PR TITLE
[HOTFIX] 리뷰 다중 조회 로직 수정

### DIFF
--- a/src/main/java/com/lxp/aplus/review/application/port/out/UserQueryPort.java
+++ b/src/main/java/com/lxp/aplus/review/application/port/out/UserQueryPort.java
@@ -1,5 +1,8 @@
 package com.lxp.aplus.review.application.port.out;
 
+import java.util.List;
+import java.util.Map;
+
 public interface UserQueryPort {
-    public String findUserName(Long userId);
+    public Map<Long, String> findUserNames(List<Long> userIds);
 }

--- a/src/main/java/com/lxp/aplus/review/application/usecase/ReviewQueryUseCase.java
+++ b/src/main/java/com/lxp/aplus/review/application/usecase/ReviewQueryUseCase.java
@@ -48,7 +48,7 @@ public class ReviewQueryUseCase {
 
 
         return reviews.map(review -> {
-            String writerName = writerNicknames.getOrDefault(review.getUserId(), "Unknown");
+            String writerName = writerNicknames.getOrDefault(review.getUserId(), "알 수 없음");
 
             return ReviewResult.of(command.userId(), writerName, review);
         });

--- a/src/main/java/com/lxp/aplus/review/application/usecase/ReviewQueryUseCase.java
+++ b/src/main/java/com/lxp/aplus/review/application/usecase/ReviewQueryUseCase.java
@@ -9,9 +9,12 @@ import com.lxp.aplus.review.application.result.ReviewWroteResult;
 import com.lxp.aplus.review.domain.Reviews;
 import com.lxp.aplus.review.domain.ReviewsRepository;
 import com.lxp.aplus.review.infrastructure.dto.ReviewWroteDto;
+
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -29,23 +32,33 @@ public class ReviewQueryUseCase {
         Reviews review = reviewRepository.getReview(command.userId(), command.courseId())
                 .orElseThrow(() -> new BusinessException(ReviewErrorCode.REVIEW_NOT_FOUND));
 
-        String nickName = userQueryPort.findUserName(command.userId());
+        String nickName = userQueryPort.findUserNames(List.of(command.userId())).get(command.userId());
 
         return ReviewResult.of(command.userId(), nickName, review);
     }
 
     public Slice<ReviewResult> findReviewsInCourse(ReviewQueryCommand command, Pageable pageable) {
         Slice<Reviews> reviews = reviewRepository.getCourseReviews(command.courseId(), pageable);
-        String nickName = userQueryPort.findUserName(command.userId());
+        List<Long> writerIds = reviews.stream()
+                .map(Reviews::getUserId)
+                .distinct()
+                .toList();
 
-        return reviews.map(review -> ReviewResult.of(command.userId(), nickName, review));
+        Map<Long, String> writerNicknames = userQueryPort.findUserNames(writerIds);
+
+
+        return reviews.map(review -> {
+            String writerName = writerNicknames.getOrDefault(review.getUserId(), "Unknown");
+
+            return ReviewResult.of(command.userId(), writerName, review);
+        });
     }
 
     public Integer countReviewsInCourse(Long courseId) {
         return reviewRepository.countCourseReviews(courseId);
     }
 
-    public List<ReviewWroteResult> checkReviewed(List<Long> courseIds, Long userId){
+    public List<ReviewWroteResult> checkReviewed(List<Long> courseIds, Long userId) {
         List<ReviewWroteDto> result = reviewRepository.checkReviewedByCourseIds(courseIds, userId);
 
         Set<Long> writtenIds = result.stream()

--- a/src/main/java/com/lxp/aplus/review/infrastructure/adapter/ReviewUserQueryAdapter.java
+++ b/src/main/java/com/lxp/aplus/review/infrastructure/adapter/ReviewUserQueryAdapter.java
@@ -3,10 +3,15 @@ package com.lxp.aplus.review.infrastructure.adapter;
 import com.lxp.aplus.common.error.BusinessException;
 import com.lxp.aplus.common.error.code.UserErrorCode;
 import com.lxp.aplus.review.application.port.out.UserQueryPort;
+import com.lxp.aplus.user.domain.User;
 import com.lxp.aplus.user.domain.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Component
 @Transactional
@@ -15,7 +20,8 @@ public class ReviewUserQueryAdapter implements UserQueryPort {
     private final UserRepository userRepository;
 
     @Override
-    public String findUserName(Long userId) {
-        return userRepository.findById(userId).orElseThrow(()-> new BusinessException(UserErrorCode.USER_NOT_FOUND)).getNickName();
+    public Map<Long, String> findUserNames(List<Long> userIds) {
+        return userRepository.findByIdIn(userIds).stream().collect(Collectors.toMap(User::getId, User::getNickName));
     }
+
 }


### PR DESCRIPTION
## ✨ 요약
리뷰 다중 조회 로직 수정

## 📝 작업 내용
리뷰 다중 조회 시 현재 로그인중인 유저 닉네임으로 모든 리뷰 작성자를 덮어씌우는 이슈 수정

## 💭 주의 사항
급하게 고치다가....발생했습니다

## 💡 리뷰 포인트
DTO 쓸지 Map쓸지 고민하다가 Map이 매핑하기 편할 것 같아서 Map으로 썼는데 Dto로 바꾸는게 나을까요?

## ✅ 테스트
- [x] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [x] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
