### PR TITLE
fix(course): 강좌 상세조회시 발생하는 NPE제거

### DIFF
--- a/http/course.http
+++ b/http/course.http
@@ -362,6 +362,13 @@ Content-Type: application/json
     "isDownloadable": false
   }
 }
+
+### 11. 강좌 상세 조회
+# 주의: 강좌 생성 API(3번)를 먼저 실행하여 courseId 변수를 설정하거나, 위에서 수동으로 설정하세요.
+GET {{baseUrl}}/api/courses/{{courseId}}
+Authorization: Bearer {{accessToken}}
+Accept: application/json
+
 --WebAppBoundary
 Content-Disposition: form-data; name="multiFile"; filename="215926_small.mp4"
 Content-Type: video/mp4

--- a/src/main/java/com/lxp/aplus/course/presentation/controller/CourseController.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/controller/CourseController.java
@@ -88,7 +88,8 @@ public class CourseController {
             @CurrentUser UserInfo userInfo,
             @PathVariable("courseId") Long courseId
     ) {
-        CourseDetailResult result = courseQueryUseCase.getPublishedCourseDetail(courseId, userInfo.id());
+        Long userId = (userInfo != null) ? userInfo.id() : null;
+        CourseDetailResult result = courseQueryUseCase.getPublishedCourseDetail(courseId, userId);
 
         return ResponseEntity
                 .status(CourseResultCode.COURSE_READ_SUCCESS.getStatus())


### PR DESCRIPTION
## ✨ 요약
강좌 상세조회시 발생하는 NPE제거

## 📝 작업 내용
비로그인 상태에서 getPublishedCourseDetail호출시 UserInfo가 null로 들어왔을때의 null체킹 및 분기 처리

## 💭 주의 사항

## 💡 리뷰 포인트

## ✅ 테스트
- [x] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [x] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
