### PR TITLE
feat(course): course 조회시 resourceId 함께 조회

### DIFF
--- a/src/main/java/com/lxp/aplus/course/application/mapper/LectureResultUrlMapper.java
+++ b/src/main/java/com/lxp/aplus/course/application/mapper/LectureResultUrlMapper.java
@@ -19,6 +19,7 @@ public class LectureResultUrlMapper {
     public LectureResourceResult toResult(LectureResourceV2 resource) {
         String url = presignedUrlGenerator.generateGetUrl(resource.getFileKey()).url();
         return LectureResourceResult.builder()
+                .resourceId(resource.getId())
                 .resourceType(resource.getResourceType())
                 .isDownloadable(resource.isDownloadable())
                 .fileUrl(url)

--- a/src/main/java/com/lxp/aplus/course/application/result/LectureResourceResult.java
+++ b/src/main/java/com/lxp/aplus/course/application/result/LectureResourceResult.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 
 @Builder
 public record LectureResourceResult(
+        Long resourceId,
         ResourceType resourceType,
         boolean isDownloadable,
         String fileUrl

--- a/src/main/java/com/lxp/aplus/course/application/result/LectureResult.java
+++ b/src/main/java/com/lxp/aplus/course/application/result/LectureResult.java
@@ -1,7 +1,6 @@
 package com.lxp.aplus.course.application.result;
 
 import com.lxp.aplus.course.domain.Lecture;
-import com.lxp.aplus.course.domain.LectureResource;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -23,6 +22,7 @@ public record LectureResult (
                 .filter(list -> !list.isEmpty())
                 .map(list -> list.get(0))
                 .map(res -> LectureResourceResult.builder()
+                        .resourceId(res.getId())
                         .resourceType(res.getResourceType())
                         .isDownloadable(res.isDownloadable())
                         .fileUrl(res.getFileKey())

--- a/src/main/java/com/lxp/aplus/course/presentation/response/LectureResourceResponse.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/response/LectureResourceResponse.java
@@ -6,12 +6,14 @@ import lombok.Builder;
 
 @Builder
 public record LectureResourceResponse(
+        Long resourceId,
         ResourceType resourceType,
         boolean isDownloadable,
         String fileUrl
 ) {
     public static LectureResourceResponse from(LectureResourceV2 resource) {
         return LectureResourceResponse.builder()
+                .resourceId(resource.getId())
                 .resourceType(resource.getResourceType())
                 .fileUrl(resource.getFileKey())
                 .isDownloadable(resource.isDownloadable())

--- a/src/main/java/com/lxp/aplus/course/presentation/response/LectureResponse.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/response/LectureResponse.java
@@ -48,6 +48,7 @@ public record LectureResponse(
                 .updatedAt(result.updatedAt())
                 .resource(
                         LectureResourceResponse.builder()
+                                .resourceId(result.resource().resourceId())
                                 .resourceType(result.resource().resourceType())
                                 .isDownloadable(result.resource().isDownloadable())
                                 .fileUrl(result.resource().fileUrl())


### PR DESCRIPTION
## ✨ 요약
- course 조회시 resourceId 함께 조회되도록 변경했습니다
<img width="682" height="702" alt="image" src="https://github.com/user-attachments/assets/9b66ea95-0a5a-47ca-a308-6ac7ac60067d" />

## 📝 작업 내용
<img width="1138" height="286" alt="image" src="https://github.com/user-attachments/assets/22c8a923-2da7-4455-8e7c-3fac7b3ddc4b" />

- 클라이언트 요청 사항 추가했습니다

## 💭 주의 사항

## 💡 리뷰 포인트

## ✅ 테스트
- [ ] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [ ] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
