### PR TITLE
[REFACTOR] CourseJpaRepository 리팩토링

### DIFF
--- a/src/main/java/com/lxp/aplus/course/infrastructure/persistence/CourseDslRepository.java
+++ b/src/main/java/com/lxp/aplus/course/infrastructure/persistence/CourseDslRepository.java
@@ -1,0 +1,89 @@
+package com.lxp.aplus.course.infrastructure.persistence;
+
+import com.lxp.aplus.course.application.port.in.dto.ResourceSummary;
+import static com.lxp.aplus.course.domain.QCourse.course;
+import static com.lxp.aplus.course.domain.QLecture.lecture;
+import static com.lxp.aplus.course.domain.QLectureResourceV2.lectureResourceV2;
+import static com.lxp.aplus.course.domain.QSection.section;
+
+import com.lxp.aplus.course.domain.Course;
+import com.lxp.aplus.course.domain.Lecture;
+import com.lxp.aplus.course.infrastructure.persistence.expressions.CourseExpressions;
+import com.lxp.aplus.course.infrastructure.persistence.expressions.LectureExpressions;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CourseDslRepository {
+    private final JPAQueryFactory queryFactory;
+
+    public List<ResourceSummary> findLectureSummariesByCourseId(Long courseId) {
+        return queryFactory
+                .select(Projections.constructor(ResourceSummary.class,
+                        lectureResourceV2.id,
+                        lecture.title,
+                        lecture.totalDurationSeconds
+                ))
+                .from(lecture)
+                .join(lecture.section, section)
+                .join(lecture.lectureResources, lectureResourceV2)
+                .where(
+                        LectureExpressions.courseIdEq(courseId),
+                        LectureExpressions.isVideoResource()
+                )
+                .orderBy(
+                        section.orderIndex.asc(),
+                        lecture.orderIndex.asc()
+                )
+                .fetch();
+    }
+
+    public Optional<Course> findWithCurriculumById(Long courseId) {
+        Course result = queryFactory
+                .selectFrom(course)
+                .distinct()
+                .leftJoin(course.sections, section).fetchJoin()
+                .where(CourseExpressions.courseIdEq(courseId))
+                .fetchOne();
+        return Optional.ofNullable(result);
+    }
+
+    public Optional<Course> findPublishedWithCurriculumById(Long courseId) {
+        Course result = queryFactory
+                .selectFrom(course)
+                .distinct()
+                .leftJoin(course.sections, section).fetchJoin()
+                .where(
+                        CourseExpressions.courseIdEq(courseId),
+                        CourseExpressions.isPublished()
+                )
+                .fetchOne();
+        return Optional.ofNullable(result);
+    }
+
+    public int countLecturesByCourseId(Long courseId) {
+        Long count = queryFactory
+                .select(lecture.count())
+                .from(lecture)
+                .innerJoin(lecture.section, section)
+                .where(LectureExpressions.courseIdEq(courseId))
+                .fetchOne();
+
+        return count != null ? count.intValue() : 0;
+    }
+
+    public List<Lecture> findAllLecturesWithResourcesByCourseId(Long courseId) {
+        return queryFactory
+                .selectFrom(lecture)
+                .distinct()
+                .leftJoin(lecture.lectureResources, lectureResourceV2).fetchJoin()
+                .innerJoin(lecture.section, section)
+                .where(LectureExpressions.courseIdEq(courseId))
+                .fetch();
+    }
+}

--- a/src/main/java/com/lxp/aplus/course/infrastructure/persistence/CourseJpaRepository.java
+++ b/src/main/java/com/lxp/aplus/course/infrastructure/persistence/CourseJpaRepository.java
@@ -1,55 +1,20 @@
 package com.lxp.aplus.course.infrastructure.persistence;
 
-import com.lxp.aplus.course.application.port.in.dto.ResourceSummary;
 import com.lxp.aplus.course.domain.Course;
 import com.lxp.aplus.course.domain.CourseStatus;
-import com.lxp.aplus.course.domain.Lecture;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.List;
-import java.util.Optional;
 
 public interface CourseJpaRepository extends JpaRepository<Course, Long> {
     Optional<Course> findByIdAndCourseStatusNot(Long id, CourseStatus courseStatus);
 
-    Page<Course> findAllByInstructorIdAndCourseStatusNot(Long instructorId, CourseStatus courseStatus, Pageable pageable);
+    Page<Course> findAllByInstructorIdAndCourseStatusNot(Long instructorId, CourseStatus courseStatus,
+                                                         Pageable pageable);
 
     Page<Course> findAllByCourseStatus(CourseStatus courseStatus, Pageable pageable);
 
-    @Query("SELECT DISTINCT c FROM Course c " +
-            "LEFT JOIN FETCH c.sections s " +
-            "WHERE c.id = :courseId")
-    Optional<Course> findWithCurriculumById(@Param("courseId") Long courseId);
-
-    @Query("SELECT DISTINCT c FROM Course c " +
-            "LEFT JOIN FETCH c.sections s " +
-            "WHERE c.id = :courseId AND c.courseStatus = 'PUBLISHED'")
-    Optional<Course> findPublishedWithCurriculumById(@Param("courseId") Long courseId);
-
-    @Query("SELECT COUNT(l) FROM Lecture l " +
-            "INNER JOIN l.section s " +
-            "WHERE s.course.id = :courseId")
-    int countLecturesByCourseId(@Param("courseId") Long courseId);
-
-    @Query("SELECT DISTINCT l FROM Lecture l " +
-            "LEFT JOIN FETCH l.lectureResources lr " +
-            "INNER JOIN l.section s " +
-            "WHERE s.course.id = :courseId")
-    List<Lecture> findAllLecturesWithResourcesByCourseId(@Param("courseId") Long courseId);
-
     List<Course> findByIdIn(List<Long> ids);
-
-    @Query("SELECT new com.lxp.aplus.course.application.port.in.dto.ResourceSummary(" +
-            "lr.id, l.title, l.totalDurationSeconds) " +
-            "FROM Lecture l " +
-            "JOIN l.section s " +
-            "JOIN l.lectureResources lr " +
-            "WHERE s.course.id = :courseId " +
-            "AND lr.resourceType = 'VIDEO' " +
-            "ORDER BY s.orderIndex ASC, l.orderIndex ASC")
-    List<ResourceSummary> findLectureSummariesByCourseId(@Param("courseId") Long courseId);
 }

--- a/src/main/java/com/lxp/aplus/course/infrastructure/persistence/CourseRepositoryImpl.java
+++ b/src/main/java/com/lxp/aplus/course/infrastructure/persistence/CourseRepositoryImpl.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class CourseRepositoryImpl implements CourseRepository {
     private final CourseJpaRepository jpaRepository;
+    private final CourseDslRepository courseDslRepository;
 
     @Override
     public Course save(Course course) {
@@ -42,22 +43,22 @@ public class CourseRepositoryImpl implements CourseRepository {
 
     @Override
     public Optional<Course> findWithCurriculumById(Long courseId) {
-        return jpaRepository.findWithCurriculumById(courseId);
+        return courseDslRepository.findWithCurriculumById(courseId);
     }
 
     @Override
     public Optional<Course> findPublishedWithCurriculumById(Long courseId) {
-        return jpaRepository.findPublishedWithCurriculumById(courseId);
+        return courseDslRepository.findPublishedWithCurriculumById(courseId);
     }
 
     @Override
     public int countLecturesByCourseId(Long courseId) {
-        return jpaRepository.countLecturesByCourseId(courseId);
+        return courseDslRepository.countLecturesByCourseId(courseId);
     }
 
     @Override
     public List<Lecture> findAllLecturesWithResourcesByCourseId(Long courseId) {
-        return jpaRepository.findAllLecturesWithResourcesByCourseId(courseId);
+        return courseDslRepository.findAllLecturesWithResourcesByCourseId(courseId);
     }
 
     @Override
@@ -67,6 +68,6 @@ public class CourseRepositoryImpl implements CourseRepository {
 
     @Override
     public List<ResourceSummary> findLectureSummariesByCourseId(Long courseId) {
-        return jpaRepository.findLectureSummariesByCourseId(courseId);
+        return courseDslRepository.findLectureSummariesByCourseId(courseId);
     }
 }

--- a/src/main/java/com/lxp/aplus/course/infrastructure/persistence/expressions/CourseExpressions.java
+++ b/src/main/java/com/lxp/aplus/course/infrastructure/persistence/expressions/CourseExpressions.java
@@ -1,0 +1,16 @@
+package com.lxp.aplus.course.infrastructure.persistence.expressions;
+
+import com.lxp.aplus.course.domain.CourseStatus;
+import static com.lxp.aplus.course.domain.QCourse.course;
+import com.querydsl.core.types.dsl.BooleanExpression;
+
+public class CourseExpressions {
+
+    public static BooleanExpression courseIdEq(Long courseId) {
+        return courseId != null ? course.id.eq(courseId) : null;
+    }
+
+    public static BooleanExpression isPublished() {
+        return course.courseStatus.eq(CourseStatus.PUBLISHED);
+    }
+}

--- a/src/main/java/com/lxp/aplus/course/infrastructure/persistence/expressions/LectureExpressions.java
+++ b/src/main/java/com/lxp/aplus/course/infrastructure/persistence/expressions/LectureExpressions.java
@@ -1,0 +1,17 @@
+package com.lxp.aplus.course.infrastructure.persistence.expressions;
+
+import static com.lxp.aplus.course.domain.QLectureResourceV2.lectureResourceV2;
+import static com.lxp.aplus.course.domain.QSection.section;
+
+import com.lxp.aplus.course.domain.ResourceType;
+import com.querydsl.core.types.dsl.BooleanExpression;
+
+public class LectureExpressions {
+    public static BooleanExpression courseIdEq(Long courseId) {
+        return courseId != null ? section.course.id.eq(courseId) : null;
+    }
+
+    public static BooleanExpression isVideoResource() {
+        return lectureResourceV2.resourceType.eq(ResourceType.VIDEO);
+    }
+}


### PR DESCRIPTION
## ✨ 요약
CourseJpaRepository 리팩토링

## 📝 작업 내용
JPQL -> QueryDSL로 변경

## 💭 주의 사항
추후 도메인 강결합 구조 개선 후 다시 한번 작업할 예정입니다.

## 💡 리뷰 포인트
QueryDSL 적용 및 조건식 분리

## ✅ 테스트
- [ ] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [ ] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
