### PR TITLE
[FEAT] 강좌 검색 및 필터링 기능 추가

### DIFF
--- a/src/main/java/com/lxp/aplus/course/application/usecase/CourseQueryUseCase.java
+++ b/src/main/java/com/lxp/aplus/course/application/usecase/CourseQueryUseCase.java
@@ -13,6 +13,7 @@ import com.lxp.aplus.course.application.result.CourseResult;
 import com.lxp.aplus.course.application.result.InstructorResult;
 import com.lxp.aplus.course.application.result.ReviewStat;
 import com.lxp.aplus.course.domain.Course;
+import com.lxp.aplus.course.domain.CourseLevel;
 import com.lxp.aplus.course.domain.CourseRepository;
 import com.lxp.aplus.review.infrastructure.persistence.dto.ReviewSummary;
 import java.util.Collections;
@@ -42,8 +43,8 @@ public class CourseQueryUseCase {
         return convertToCourseResponse(courses, pageable);
     }
 
-    public Page<CourseResult> getPublishedCourses(Pageable pageable) {
-        Page<Course> courses = courseRepository.findAllPublished(pageable);
+    public Page<CourseResult> getPublishedCourses(String title, Long categoryId, CourseLevel level, Pageable pageable) {
+        Page<Course> courses = courseRepository.findAllPublishedWithFilters(title, categoryId, level, pageable);
         return convertToCourseResponse(courses, pageable);
     }
 

--- a/src/main/java/com/lxp/aplus/course/domain/CourseRepository.java
+++ b/src/main/java/com/lxp/aplus/course/domain/CourseRepository.java
@@ -15,6 +15,7 @@ public interface CourseRepository {
     Optional<Course> findPublishedWithCurriculumById(Long courseId);
     Page<Course> findAllByInstructorIdExcludingDeleted(Long instructorId, Pageable pageable);
     Page<Course> findAllPublished(Pageable pageable);
+    Page<Course> findAllPublishedWithFilters(String title, Long categoryId, CourseLevel level, Pageable pageable);
     int countLecturesByCourseId(Long courseId);
     List<Lecture> findAllLecturesWithResourcesByCourseId(Long courseId);
     List<Course> findByIdIn(List<Long> ids);

--- a/src/main/java/com/lxp/aplus/course/infrastructure/persistence/CourseJpaRepository.java
+++ b/src/main/java/com/lxp/aplus/course/infrastructure/persistence/CourseJpaRepository.java
@@ -2,6 +2,7 @@ package com.lxp.aplus.course.infrastructure.persistence;
 
 import com.lxp.aplus.course.application.port.in.dto.ResourceSummary;
 import com.lxp.aplus.course.domain.Course;
+import com.lxp.aplus.course.domain.CourseLevel;
 import com.lxp.aplus.course.domain.CourseStatus;
 import com.lxp.aplus.course.domain.Lecture;
 import org.springframework.data.domain.Page;
@@ -52,4 +53,10 @@ public interface CourseJpaRepository extends JpaRepository<Course, Long> {
             "AND lr.resourceType = 'VIDEO' " +
             "ORDER BY s.orderIndex ASC, l.orderIndex ASC")
     List<ResourceSummary> findLectureSummariesByCourseId(@Param("courseId") Long courseId);
+
+    @Query("SELECT c FROM Course c WHERE c.courseStatus = 'PUBLISHED' " +
+            "AND (:title IS NULL OR LOWER(c.title) LIKE LOWER(CONCAT('%', :title, '%'))) " +
+            "AND (:categoryId IS NULL OR c.categoryId = :categoryId) " +
+            "AND (:level IS NULL OR c.courseLevel = :level)")
+    Page<Course> findAllPublishedWithFilters(@Param("title") String title, @Param("categoryId") Long categoryId, @Param("level") CourseLevel level, Pageable pageable);
 }

--- a/src/main/java/com/lxp/aplus/course/infrastructure/persistence/CourseRepositoryImpl.java
+++ b/src/main/java/com/lxp/aplus/course/infrastructure/persistence/CourseRepositoryImpl.java
@@ -1,7 +1,11 @@
 package com.lxp.aplus.course.infrastructure.persistence;
 
 import com.lxp.aplus.course.application.port.in.dto.ResourceSummary;
-import com.lxp.aplus.course.domain.*;
+import com.lxp.aplus.course.domain.Course;
+import com.lxp.aplus.course.domain.CourseLevel;
+import com.lxp.aplus.course.domain.CourseRepository;
+import com.lxp.aplus.course.domain.CourseStatus;
+import com.lxp.aplus.course.domain.Lecture;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -38,6 +42,11 @@ public class CourseRepositoryImpl implements CourseRepository {
     @Override
     public Page<Course> findAllPublished(Pageable pageable) {
         return jpaRepository.findAllByCourseStatus(CourseStatus.PUBLISHED, pageable);
+    }
+
+    @Override
+    public Page<Course> findAllPublishedWithFilters(String title, Long categoryId, CourseLevel level, Pageable pageable) {
+        return jpaRepository.findAllPublishedWithFilters(title, categoryId, level, pageable);
     }
 
     @Override

--- a/src/main/java/com/lxp/aplus/course/presentation/controller/CourseController.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/controller/CourseController.java
@@ -25,7 +25,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -33,9 +32,10 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
+
+import com.lxp.aplus.course.domain.CourseLevel;
 
 @RestController
 @RequiredArgsConstructor
@@ -112,9 +112,12 @@ public class CourseController {
 
     @GetMapping("/api/courses")
     public ResponseEntity<ResultResponse<PageResponse<CourseResponse>>> getPublishedCourses(
+            @RequestParam(required = false) String title,
+            @RequestParam(required = false) Long categoryId,
+            @RequestParam(required = false) CourseLevel level,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        Page<CourseResult> result = courseQueryUseCase.getPublishedCourses(pageable);
+        Page<CourseResult> result = courseQueryUseCase.getPublishedCourses(title, categoryId, level, pageable);
         Page<CourseResponse> responsePage = result.map(CourseResponse::from);
 
         return ResponseEntity


### PR DESCRIPTION


<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ✨ 요약
- CourseRepository, CourseJpaRepository, CourseRepositoryImpl에 필터링 메서드 추가 
- CourseQueryUseCase에 필터 파라미터 오버로딩
- CourseController에 title, categoryId, level RequestParam 추가 대소문자 무시 검색 및 선택적 필터링 지원

## 📝 작업 내용
- CourseRepository 인터페이스에 findAllPublishedWithFilters 메서드 추가
- CourseJpaRepository에 조건부 WHERE 절을 사용한 @Query 추가 (대소문자 무시 검색 포함)
- CourseRepositoryImpl에 JPA 리포지토리 호출 구현
- CourseQueryUseCase에 필터 파라미터를 받는 오버로딩된 getPublishedCourses 메서드 추가
- CourseController의 getPublishedCourses에 @RequestParam으로 title, categoryId, level 추가
- 모든 파라미터는 선택적이며, null일 경우 필터링되지 않음

## 💭 주의 사항
- 필터링 시 대소문자 무시를 위해 LOWER 함수 사용
- Pageable을 사용하여 페이징 지원

## 💡 리뷰 포인트
- 필터링 로직의 정확성 검증

## ✅ 테스트
- [x] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [x] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
