### PR TITLE
[FEAT] 강좌 썸네일 생성 api #157

### DIFF
--- a/src/main/java/com/lxp/aplus/common/error/code/CourseErrorCode.java
+++ b/src/main/java/com/lxp/aplus/common/error/code/CourseErrorCode.java
@@ -13,7 +13,13 @@ public enum CourseErrorCode implements ErrorCode {
     CANNOT_MODIFY_PUBLISHED_COURSE(HttpStatus.BAD_REQUEST, "EC003", "이미 발행된 강좌는 수정하거나 삭제할 수 없습니다."),
     COURSE_SECTION_EMPTY(HttpStatus.BAD_REQUEST, "EC004", "강좌에는 최소 1개 이상의 섹션이 있어야 합니다."),
     COURSE_LECTURE_EMPTY(HttpStatus.BAD_REQUEST, "EC005", "모든 섹션에는 최소 1개 이상의 강의가 있어야 합니다."),
-    COURSE_CONTENT_EMPTY(HttpStatus.BAD_REQUEST, "EC006", "모든 강의에는 영상 또는 자료가 등록되어야 합니다.");
+    COURSE_CONTENT_EMPTY(HttpStatus.BAD_REQUEST, "EC006", "모든 강의에는 영상 또는 자료가 등록되어야 합니다."),
+    COURSE_THUMBNAIL_EXTENSION_MISSING(HttpStatus.BAD_REQUEST, "EC007", "강좌 썸네일 파일에는 확장자가 포함되어야 합니다."),
+    COURSE_THUMBNAIL_EXTENSION_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "EC008", "강좌 썸네일은 jpg, jpeg, png, webp 형식만 업로드할 수 있습니다."),
+    COURSE_THUMBNAIL_CONTENT_TYPE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "EC009", "강좌 썸네일은 image/jpeg, image/png, image/webp 형식만 업로드할 수 있습니다."),;
+
+
+
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/lxp/aplus/common/result/code/CourseResultCode.java
+++ b/src/main/java/com/lxp/aplus/common/result/code/CourseResultCode.java
@@ -10,10 +10,11 @@ import org.springframework.http.HttpStatus;
 public enum CourseResultCode implements ResultCode {
     COURSE_REGISTER_SUCCESS(HttpStatus.CREATED, "SC001", "강좌가 정상적으로 등록되었습니다."),
     COURSE_UPDATE_SUCCESS(HttpStatus.OK, "SC002", "강좌 정보가 수정되었습니다."),
-    COURSE_READ_SUCCESS(HttpStatus.OK, "SC003","강좌 조회에 성공했습니다."),
+    COURSE_READ_SUCCESS(HttpStatus.OK, "SC003", "강좌 조회에 성공했습니다."),
     COURSE_LIST_SUCCESS(HttpStatus.OK, "SC004", "강좌 목록 조회에 성공했습니다."),
     COURSE_DELETE_SUCCESS(HttpStatus.OK, "SC005", "강좌가 삭제되었습니다."),
-    COURSE_PUBLISH_SUCCESS(HttpStatus.OK, "SC006", "강좌가 정상적으로 게시되었습니다.");
+    COURSE_PUBLISH_SUCCESS(HttpStatus.OK, "SC006", "강좌가 정상적으로 게시되었습니다."),
+    COURSE_THUMBNAIL_PRESIGN_SUCCESS(HttpStatus.OK, "SC007", "강좌 썸네일 업로드 URL 발급에 성공했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/lxp/aplus/course/application/command/CourseThumbnailPresignCommand.java
+++ b/src/main/java/com/lxp/aplus/course/application/command/CourseThumbnailPresignCommand.java
@@ -1,0 +1,14 @@
+package com.lxp.aplus.course.application.command;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CourseThumbnailPresignCommand(
+
+        @NotBlank
+        @Size(max = 255)
+        String originalFileName,
+
+        @NotBlank
+        String contentType
+) {}

--- a/src/main/java/com/lxp/aplus/course/application/command/CourseThumbnailPresignCommand.java
+++ b/src/main/java/com/lxp/aplus/course/application/command/CourseThumbnailPresignCommand.java
@@ -5,10 +5,10 @@ import jakarta.validation.constraints.Size;
 
 public record CourseThumbnailPresignCommand(
 
-        @NotBlank
-        @Size(max = 255)
+        @NotBlank(message = "파일명은 필수입니다.")
+        @Size(max = 255, message = "파일명은 255자를 넘어갈 수 없습니다.")
         String originalFileName,
 
-        @NotBlank
+        @NotBlank(message = "컨텐츠 타입은 필수입니다.")
         String contentType
 ) {}

--- a/src/main/java/com/lxp/aplus/course/application/command/CourseUpdateCommand.java
+++ b/src/main/java/com/lxp/aplus/course/application/command/CourseUpdateCommand.java
@@ -10,6 +10,6 @@ public record CourseUpdateCommand(
         String description,
         Long categoryId,
         Integer price,
-        String thumbnailUrl,
+        String thumbnailResourceKey,
         CourseLevel courseLevel
 ) {}

--- a/src/main/java/com/lxp/aplus/course/application/port/out/PresignedUrlGenerator.java
+++ b/src/main/java/com/lxp/aplus/course/application/port/out/PresignedUrlGenerator.java
@@ -8,4 +8,7 @@ public interface PresignedUrlGenerator {
     PresignedUrlResult generatePutUrl(String originalFileName, String contentType);
 
     PresignedUrlResult generateDeleteUrl(String key);
+
+    PresignedUrlResult generatePutUrlWithKey(String key, String contentType);
+
 }

--- a/src/main/java/com/lxp/aplus/course/application/result/CourseThumbnailPresignResult.java
+++ b/src/main/java/com/lxp/aplus/course/application/result/CourseThumbnailPresignResult.java
@@ -1,0 +1,22 @@
+package com.lxp.aplus.course.application.result;
+
+public record CourseThumbnailPresignResult(
+        String uploadUrl,     // S3 presigned PUT url
+        String fileKey,       // courses/thumbnails/...
+        String fileUrl,       // CDN or public access URL (미리보기용)
+        int expiresInSeconds  // presigned URL 만료 시간(초)
+) {
+    public static CourseThumbnailPresignResult of(
+            String uploadUrl,
+            String fileKey,
+            String fileUrl,
+            int expiresInSeconds
+    ) {
+        return new CourseThumbnailPresignResult(
+                uploadUrl,
+                fileKey,
+                fileUrl,
+                expiresInSeconds
+        );
+    }
+}

--- a/src/main/java/com/lxp/aplus/course/application/usecase/CourseThumbnailPresignUseCase.java
+++ b/src/main/java/com/lxp/aplus/course/application/usecase/CourseThumbnailPresignUseCase.java
@@ -1,0 +1,43 @@
+package com.lxp.aplus.course.application.usecase;
+
+import com.lxp.aplus.common.error.BusinessException;
+import com.lxp.aplus.common.error.code.CourseErrorCode;
+import com.lxp.aplus.course.application.command.CourseThumbnailPresignCommand;
+import com.lxp.aplus.course.application.port.out.PresignedUrlGenerator;
+import com.lxp.aplus.course.application.result.CourseThumbnailPresignResult;
+import com.lxp.aplus.course.application.result.PresignedUrlResult;
+import com.lxp.aplus.course.infrastructure.file.CourseThumbnailKeyGenerator;
+import com.lxp.aplus.course.infrastructure.file.FileUrlGenerator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class CourseThumbnailPresignUseCase {
+
+    private static final Set<String> ALLOWED = Set.of("image/jpeg","image/png","image/webp");
+
+    private final PresignedUrlGenerator presignedUrlGenerator;
+    private final CourseThumbnailKeyGenerator keyGenerator;
+    private final FileUrlGenerator fileUrlGenerator;
+
+    public CourseThumbnailPresignResult presign(Long instructorId, CourseThumbnailPresignCommand req) {
+        if (!ALLOWED.contains(req.contentType())) {
+            throw new BusinessException(CourseErrorCode.COURSE_THUMBNAIL_CONTENT_TYPE_NOT_ALLOWED);
+        }
+
+        String key = keyGenerator.generate(instructorId, req.originalFileName());
+
+        PresignedUrlResult presigned = presignedUrlGenerator.generatePutUrlWithKey(key, req.contentType());
+
+        return CourseThumbnailPresignResult.of(
+                presigned.url(),
+                presigned.key(),
+                fileUrlGenerator.generate(presigned.key()),
+                presigned.expireSeconds()
+        );
+
+    }
+}

--- a/src/main/java/com/lxp/aplus/course/domain/Course.java
+++ b/src/main/java/com/lxp/aplus/course/domain/Course.java
@@ -112,11 +112,11 @@ public class Course extends BaseAggregateRoot {
             this.categoryId = command.categoryId();
         }
 
-        if (command.thumbnailUrl() != null) {
-            if (command.thumbnailUrl().isBlank()) {
+        if (command.thumbnailResourceKey() != null) {
+            if (command.thumbnailResourceKey().isBlank()) {
                 throw new BusinessException(GlobalErrorCode.INVALID_ARGUMENT);
             }
-            this.thumbnailResourceKey = command.thumbnailUrl();
+            this.thumbnailResourceKey = command.thumbnailResourceKey();
         }
 
         if (command.price() != null) {

--- a/src/main/java/com/lxp/aplus/course/infrastructure/file/CourseThumbnailKeyGenerator.java
+++ b/src/main/java/com/lxp/aplus/course/infrastructure/file/CourseThumbnailKeyGenerator.java
@@ -1,0 +1,30 @@
+package com.lxp.aplus.course.infrastructure.file;
+import com.lxp.aplus.common.error.BusinessException;
+import com.lxp.aplus.common.error.code.CourseErrorCode;
+import com.lxp.aplus.common.error.code.GlobalErrorCode;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CourseThumbnailKeyGenerator {
+
+    private static final String DIRECTORY_FORMAT =
+            "courses/thumbnails/%d/%s/%s.%s"; // instructorId / yyyyMM / uuid / ext
+
+    public String generate(Long instructorId, String originalFileName) {
+        String ext = extractImageExt(originalFileName);
+        String ym = java.time.LocalDate.now().format(java.time.format.DateTimeFormatter.ofPattern("yyyy/MM"));
+        String uuid = java.util.UUID.randomUUID().toString().replace("-", "");
+        return String.format(DIRECTORY_FORMAT, instructorId, ym, uuid, ext);
+    }
+
+    private String extractImageExt(String originalFileName) {
+        int idx = originalFileName.lastIndexOf('.');
+        if (idx < 0) throw new BusinessException(CourseErrorCode.COURSE_THUMBNAIL_EXTENSION_MISSING);
+        String ext = originalFileName.substring(idx + 1).toLowerCase();
+        return switch (ext) {
+            case "jpg" -> "jpeg";
+            case "jpeg", "png", "webp" -> ext;
+            default -> throw new BusinessException(CourseErrorCode.COURSE_THUMBNAIL_EXTENSION_NOT_ALLOWED);
+        };
+    }
+}

--- a/src/main/java/com/lxp/aplus/course/infrastructure/file/s3/S3PresignedUrlGenerator.java
+++ b/src/main/java/com/lxp/aplus/course/infrastructure/file/s3/S3PresignedUrlGenerator.java
@@ -86,4 +86,25 @@ public class S3PresignedUrlGenerator implements PresignedUrlGenerator {
         expiration.setTime(expTimeMillis);
         return expiration;
     }
+
+    // 썸네일 PresignedURL 발급을 위한 메서드 재정의
+
+    @Override
+    public PresignedUrlResult generatePutUrlWithKey(String key, String contentType) {
+        Date expiration = getExpiration();
+
+        GeneratePresignedUrlRequest req = new GeneratePresignedUrlRequest(bucket, key)
+                .withMethod(HttpMethod.PUT)
+                .withExpiration(expiration);
+
+        URL url = amazonS3Client.generatePresignedUrl(req);
+
+        return new PresignedUrlResult(
+                url.toExternalForm(),
+                key,
+                "PUT",
+                expireMilliSeconds / 1000
+        );
+    }
+
 }

--- a/src/main/java/com/lxp/aplus/course/presentation/controller/CourseThumbnailUploadController.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/controller/CourseThumbnailUploadController.java
@@ -1,0 +1,28 @@
+package com.lxp.aplus.course.presentation.controller;
+
+import com.lxp.aplus.common.security.Authenticated;
+import com.lxp.aplus.common.security.InstructorOnly;
+import com.lxp.aplus.course.application.command.CourseThumbnailPresignCommand;
+import com.lxp.aplus.course.application.result.CourseThumbnailPresignResult;
+import com.lxp.aplus.course.application.usecase.CourseThumbnailPresignUseCase;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/uploads/courses/thumbnails")
+public class CourseThumbnailUploadController {
+
+    private final CourseThumbnailPresignUseCase courseThumbnailPresignUseCase;
+
+    @InstructorOnly
+    @PostMapping("/presign")
+    public ResponseEntity<CourseThumbnailPresignResult> presign(
+            @Authenticated Long instructorId,
+            @RequestBody @Valid CourseThumbnailPresignCommand command
+    ) {
+        return ResponseEntity.ok(courseThumbnailPresignUseCase.presign(instructorId, command));
+    }
+}

--- a/src/main/java/com/lxp/aplus/course/presentation/request/CourseUpdateRequest.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/request/CourseUpdateRequest.java
@@ -9,7 +9,7 @@ public record CourseUpdateRequest(
         String description,
         Long categoryId,
         CourseLevel courseLevel,
-        String thumbnailUrl,
+        String thumbnailResourceKey,
         Integer price
 ) {
     public CourseUpdateCommand toCommand() {
@@ -19,7 +19,7 @@ public record CourseUpdateRequest(
                 .description(this.description)
                 .categoryId(this.categoryId)
                 .courseLevel(this.courseLevel)
-                .thumbnailUrl(this.thumbnailUrl)
+                .thumbnailResourceKey(this.thumbnailResourceKey)
                 .price(this.price)
                 .build();
     }


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ✨ 요약
강좌 썸네일 PresignedURL 발급 api 구현

## 📝 작업 내용
썸네일 등록을 위한 PresignedURL 발급이 가능합니다.

TODO :
- 동훈님과 상의 후 Couse 생성/조회/수정 시에 썸네일 상호작용 어떻게 할 지 논의
- 의존성 제거

## 💭 주의 사항
- 의존성 제거는 아직 미구현입니다.

## 💡 리뷰 포인트

## ✅ 테스트
- [x] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [x] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
<img width="2003" height="1458" alt="image" src="https://github.com/user-attachments/assets/c4d5d0d7-1f31-46d1-aaa5-879271f57540" />

<img width="2007" height="1475" alt="image" src="https://github.com/user-attachments/assets/3af2c111-4086-4004-a8ca-1f6faacd43ad" />
