### PR TITLE
[FEAT] 관리자용 강사 신청 목록 조회 API

### DIFF
--- a/http/api.http
+++ b/http/api.http
@@ -7,8 +7,8 @@
 @contentType = application/json
 
 ### 테스트용 사용자 정보 (통일)
-@testEmail = test3@example.com
-@testPassword = password123
+@testEmail = admin@example.com
+@testPassword = admin
 @testName = 테스트 사용자2
 @testNickName = testuser2
 @testPhoneNumber = 010-1234-5679

--- a/src/main/java/com/lxp/aplus/common/result/code/UserResultCode.java
+++ b/src/main/java/com/lxp/aplus/common/result/code/UserResultCode.java
@@ -21,6 +21,7 @@ public enum UserResultCode implements ResultCode {
     LOGOUT_SUCCESS(HttpStatus.OK, "SU011", "로그아웃에 성공하였습니다."),
     TOKEN_REFRESH_SUCCESS(HttpStatus.OK, "SU012", "토큰이 재발급되었습니다."),
     INSTRUCTOR_APPLICATION_SUCCESS(HttpStatus.OK, "SU013", "강사 권한 요청이 정상적으로 접수되었습니다."),
+    INSTRUCTOR_APPLICATION_LIST_SUCCESS(HttpStatus.OK, "SU014", "강사 권한 요청 목록을 정상적으로 조회하였습니다."),
     INSTRUCTOR_APPLICATION_APPROVED(HttpStatus.OK, "SU015", "강사 권한이 수락되었습니다."),
     INSTRUCTOR_APPLICATION_REJECTED(HttpStatus.OK, "SU016", "강사 권한이 거절되었습니다.");
 

--- a/src/main/java/com/lxp/aplus/course/presentation/controller/CourseController.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/controller/CourseController.java
@@ -112,12 +112,12 @@ public class CourseController {
 
     @GetMapping("/api/courses")
     public ResponseEntity<ResultResponse<PageResponse<CourseResponse>>> getPublishedCourses(
-            @RequestParam(required = false) String title,
+            @RequestParam(required = false) String keyword,
             @RequestParam(required = false) Long categoryId,
             @RequestParam(required = false) CourseLevel level,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        Page<CourseResult> result = courseQueryUseCase.getPublishedCourses(title, categoryId, level, pageable);
+        Page<CourseResult> result = courseQueryUseCase.getPublishedCourses(keyword, categoryId, level, pageable);
         Page<CourseResponse> responsePage = result.map(CourseResponse::from);
 
         return ResponseEntity

--- a/src/main/java/com/lxp/aplus/user/application/dto/response/InstructorApplicationCreateResponse.java
+++ b/src/main/java/com/lxp/aplus/user/application/dto/response/InstructorApplicationCreateResponse.java
@@ -5,20 +5,16 @@ import com.lxp.aplus.user.domain.InstructorApplicationStatus;
 
 import java.time.LocalDateTime;
 
-public record InstructorApplicationResponse(
+public record InstructorApplicationCreateResponse(
         Long applicationId,
         Long userId,
-        String email,
-        String name,
         InstructorApplicationStatus status,
         LocalDateTime appliedAt
 ) {
-    public static InstructorApplicationResponse of(InstructorApplication application, String email, String name) {
-        return new InstructorApplicationResponse(
+    public static InstructorApplicationCreateResponse from(InstructorApplication application) {
+        return new InstructorApplicationCreateResponse(
                 application.getId(),
                 application.getUserId(),
-                email,
-                name,
                 application.getStatus(),
                 application.getCreatedAt()
         );

--- a/src/main/java/com/lxp/aplus/user/application/port/in/UserCommandUseCase.java
+++ b/src/main/java/com/lxp/aplus/user/application/port/in/UserCommandUseCase.java
@@ -6,9 +6,9 @@ import com.lxp.aplus.user.application.dto.request.CreateUserRequest;
 import com.lxp.aplus.user.application.dto.request.DeleteUserRequest;
 import com.lxp.aplus.user.application.dto.request.UpdateUserInfoRequest;
 import com.lxp.aplus.user.application.dto.request.WithdrawUserRequest;
+import com.lxp.aplus.user.application.dto.response.InstructorApplicationCreateResponse;
 import com.lxp.aplus.user.application.dto.response.UserResponse;
 import com.lxp.aplus.user.domain.InstructorApplicationStatus;
-import com.lxp.aplus.user.application.dto.response.InstructorApplicationResponse;
 
 public interface UserCommandUseCase {
     UserResponse createUser(CreateUserRequest request);
@@ -17,7 +17,7 @@ public interface UserCommandUseCase {
 
     UserResponse addInstructorRole(Long userId);
 
-    InstructorApplicationResponse applyForInstructor(Long userId);
+    InstructorApplicationCreateResponse applyForInstructor(Long userId);
 
     void processInstructorApplication(Long userId, Long applicationId, InstructorApplicationStatus status);
 

--- a/src/main/java/com/lxp/aplus/user/application/port/in/UserQueryUseCase.java
+++ b/src/main/java/com/lxp/aplus/user/application/port/in/UserQueryUseCase.java
@@ -1,8 +1,12 @@
 package com.lxp.aplus.user.application.port.in;
 
 import com.lxp.aplus.user.application.dto.AuthUser;
+import com.lxp.aplus.user.application.dto.response.InstructorApplicationResponse;
 import com.lxp.aplus.user.application.dto.response.UserResponse;
 import com.lxp.aplus.user.domain.User;
+import com.lxp.aplus.user.domain.InstructorApplicationStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
@@ -20,4 +24,6 @@ public interface UserQueryUseCase {
     Optional<UserResponse> findUserWithRolesById(Long id);
 
     boolean existsById(Long id);
+
+    Page<InstructorApplicationResponse> getInstructorApplications(InstructorApplicationStatus status, Pageable pageable);
 }

--- a/src/main/java/com/lxp/aplus/user/application/port/out/InstructorApplicationRepository.java
+++ b/src/main/java/com/lxp/aplus/user/application/port/out/InstructorApplicationRepository.java
@@ -1,6 +1,9 @@
 package com.lxp.aplus.user.application.port.out;
 
 import com.lxp.aplus.user.domain.InstructorApplication;
+import com.lxp.aplus.user.domain.InstructorApplicationStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
@@ -8,4 +11,6 @@ public interface InstructorApplicationRepository {
     InstructorApplication save(InstructorApplication application);
     Optional<InstructorApplication> findById(Long id);
     Optional<InstructorApplication> findByUserId(Long userId);
+    Page<InstructorApplication> findAll(Pageable pageable);
+    Page<InstructorApplication> findAllByStatus(InstructorApplicationStatus status, Pageable pageable);
 }

--- a/src/main/java/com/lxp/aplus/user/application/service/UserService.java
+++ b/src/main/java/com/lxp/aplus/user/application/service/UserService.java
@@ -10,6 +10,7 @@ import com.lxp.aplus.user.application.dto.request.CreateUserRequest;
 import com.lxp.aplus.user.application.dto.request.DeleteUserRequest;
 import com.lxp.aplus.user.application.dto.request.UpdateUserInfoRequest;
 import com.lxp.aplus.user.application.dto.request.WithdrawUserRequest;
+import com.lxp.aplus.user.application.dto.response.InstructorApplicationCreateResponse;
 import com.lxp.aplus.user.application.dto.response.InstructorApplicationResponse;
 import com.lxp.aplus.user.application.dto.response.UserResponse;
 import com.lxp.aplus.user.application.port.in.UserCommandUseCase;
@@ -21,10 +22,16 @@ import com.lxp.aplus.user.application.port.out.InstructorApplicationRepository;
 import com.lxp.aplus.user.domain.InstructorApplication;
 import com.lxp.aplus.user.domain.InstructorApplicationStatus;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * User 도메인의 통합 서비스
@@ -83,6 +90,34 @@ public class UserService implements UserCommandUseCase, UserQueryUseCase {
         return userRepository.existsById(id);
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public Page<InstructorApplicationResponse> getInstructorApplications(InstructorApplicationStatus status, Pageable pageable) {
+        Page<InstructorApplication> applications = (status != null)
+                ? instructorApplicationRepository.findAllByStatus(status, pageable)
+                : instructorApplicationRepository.findAll(pageable);
+
+        // userId 목록 추출
+        List<Long> userIds = applications.getContent().stream()
+                .map(InstructorApplication::getUserId)
+                .distinct()
+                .toList();
+
+        // user 정보 batch 조회
+        Map<Long, User> userMap = userRepository.findByIdIn(userIds).stream()
+                .collect(Collectors.toMap(User::getId, user -> user));
+
+        // InstructorApplicationListItem으로 변환
+        List<InstructorApplicationResponse> items = applications.getContent().stream()
+                .map(application -> {
+                    User user = userMap.get(application.getUserId());
+                    return InstructorApplicationResponse.of(application, user.getEmail(), user.getNickName());
+                })
+                .toList();
+
+        return new PageImpl<>(items, pageable, applications.getTotalElements());
+    }
+
     // ========== Command Methods (명령) ==========
 
     @Override
@@ -124,14 +159,14 @@ public class UserService implements UserCommandUseCase, UserQueryUseCase {
 
     @Override
     @Transactional
-    public InstructorApplicationResponse applyForInstructor(Long userId) {
+    public InstructorApplicationCreateResponse applyForInstructor(Long userId) {
         // 이미 신청한 경우 확인
         if (instructorApplicationRepository.findByUserId(userId).isPresent()) {
             throw new BusinessException(UserErrorCode.INSTRUCTOR_APPLICATION_ALREADY_EXISTS);
         }
         InstructorApplication application = InstructorApplication.create(userId);
         InstructorApplication savedApplication = instructorApplicationRepository.save(application);
-        return InstructorApplicationResponse.from(savedApplication);
+        return InstructorApplicationCreateResponse.from(savedApplication);
     }
 
     private UserResponse addRole(Long userId) {

--- a/src/main/java/com/lxp/aplus/user/infrastructure/persistence/InstructorApplicationJpaRepository.java
+++ b/src/main/java/com/lxp/aplus/user/infrastructure/persistence/InstructorApplicationJpaRepository.java
@@ -1,10 +1,14 @@
 package com.lxp.aplus.user.infrastructure.persistence;
 
 import com.lxp.aplus.user.domain.InstructorApplication;
+import com.lxp.aplus.user.domain.InstructorApplicationStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface InstructorApplicationJpaRepository extends JpaRepository<InstructorApplication, Long> {
     Optional<InstructorApplication> findByUserId(Long userId);
+    Page<InstructorApplication> findAllByStatus(InstructorApplicationStatus status, Pageable pageable);
 }

--- a/src/main/java/com/lxp/aplus/user/infrastructure/persistence/InstructorApplicationRepositoryImpl.java
+++ b/src/main/java/com/lxp/aplus/user/infrastructure/persistence/InstructorApplicationRepositoryImpl.java
@@ -2,7 +2,10 @@ package com.lxp.aplus.user.infrastructure.persistence;
 
 import com.lxp.aplus.user.application.port.out.InstructorApplicationRepository;
 import com.lxp.aplus.user.domain.InstructorApplication;
+import com.lxp.aplus.user.domain.InstructorApplicationStatus;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -25,5 +28,15 @@ public class InstructorApplicationRepositoryImpl implements InstructorApplicatio
     @Override
     public Optional<InstructorApplication> findByUserId(Long userId) {
         return jpaRepository.findByUserId(userId);
+    }
+
+    @Override
+    public Page<InstructorApplication> findAll(Pageable pageable) {
+        return jpaRepository.findAll(pageable);
+    }
+
+    @Override
+    public Page<InstructorApplication> findAllByStatus(InstructorApplicationStatus status, Pageable pageable) {
+        return jpaRepository.findAllByStatus(status, pageable);
     }
 }

--- a/src/main/java/com/lxp/aplus/user/presentation/controller/UserController.java
+++ b/src/main/java/com/lxp/aplus/user/presentation/controller/UserController.java
@@ -1,12 +1,14 @@
 package com.lxp.aplus.user.presentation.controller;
 
+import com.lxp.aplus.common.result.PageResponse;
 import com.lxp.aplus.common.result.ResultResponse;
 import com.lxp.aplus.common.result.code.UserResultCode;
 import com.lxp.aplus.common.security.AdminOnly;
 import com.lxp.aplus.common.security.Authenticated;
-import com.lxp.aplus.common.security.InstructorOnly;
 import com.lxp.aplus.common.security.UserInfo;
 import com.lxp.aplus.user.application.dto.request.InstructorApplicationProcessRequest;
+import com.lxp.aplus.user.application.dto.response.InstructorApplicationCreateResponse;
+import com.lxp.aplus.user.application.dto.response.InstructorApplicationResponse;
 import com.lxp.aplus.user.application.dto.response.UserResponse;
 import com.lxp.aplus.user.application.dto.request.UpdateMyInfoRequest;
 import com.lxp.aplus.user.application.dto.request.UpdateUserInfoRequest;
@@ -18,10 +20,12 @@ import com.lxp.aplus.user.application.port.in.UserQueryUseCase;
 import com.lxp.aplus.user.domain.InstructorApplicationStatus;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import com.lxp.aplus.user.application.dto.response.InstructorApplicationResponse;
 
 @RestController
 @RequestMapping("/api/users")
@@ -112,9 +116,23 @@ public class UserController {
      * POST /api/users/instructor/applications
      */
     @PostMapping("/instructor/applications")
-    public ResponseEntity<ResultResponse<InstructorApplicationResponse>> applyForInstructor(@Authenticated Long userId) {
-        InstructorApplicationResponse response = userCommandUseCase.applyForInstructor(userId);
+    public ResponseEntity<ResultResponse<InstructorApplicationCreateResponse>> applyForInstructor(@Authenticated Long userId) {
+        InstructorApplicationCreateResponse response = userCommandUseCase.applyForInstructor(userId);
         return ResponseEntity.ok(ResultResponse.of(UserResultCode.INSTRUCTOR_APPLICATION_SUCCESS, response));
+    }
+
+    /**
+     * 강사 신청 목록 조회 API (관리자용)
+     * GET /api/users/instructor/applications
+     */
+    @AdminOnly
+    @GetMapping("/instructor/applications")
+    public ResponseEntity<ResultResponse<PageResponse<InstructorApplicationResponse>>> getInstructorApplications(
+            @Authenticated Long userId,
+            @RequestParam(required = false) InstructorApplicationStatus status,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<InstructorApplicationResponse> result = userQueryUseCase.getInstructorApplications(status, pageable);
+        return ResponseEntity.ok(ResultResponse.of(UserResultCode.INSTRUCTOR_APPLICATION_LIST_SUCCESS, PageResponse.from(result)));
     }
 
     /**


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ✨ 요약
관리자가 강사 신청 목록을 조회할 수 있는 API를 구현했습니다. 상태 필터링과 페이징을 지원합니다.

## 📝 작업 내용
- UserController에 @AdminOnly 어노테이션이 적용된 getInstructorApplications 메서드를 추가했습니다.
- UserQueryUseCase의 getInstructorApplications 메서드를 호출하여 강사 신청 목록을 조회합니다.
- 요청 파라미터로 InstructorApplicationStatus 상태 필터링과 Pageable을 사용하여 페이징을 지원합니다.
- 응답으로 PageResponse<InstructorApplicationResponse>를 반환합니다.

## 💭 주의 사항
- 관리자 권한이 없는 사용자는 접근할 수 없습니다.

## 💡 리뷰 포인트
- API 엔드포인트와 응답 구조가 적절한지 확인해주세요.

## ✅ 테스트
- [x] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [x] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
