### PR TITLE
[REFAC] 수강 응답 필드명 정리 및 카테고리 의존성 완화

### DIFF
--- a/src/main/java/com/lxp/aplus/category/application/internal/dto/CategoryInternalResult.java
+++ b/src/main/java/com/lxp/aplus/category/application/internal/dto/CategoryInternalResult.java
@@ -14,6 +14,9 @@ public record CategoryInternalResult(
         List<Long> childrenIds
 ) {
         public static CategoryInternalResult from(Category category) {
+            if (category == null) {
+                return null;
+            }
             String parentName = category.getParent() != null ? category.getParent().getName() : null;
             List<Long> childrenIds = category.getChildren().stream()
                     .map(Category::getId)

--- a/src/main/java/com/lxp/aplus/category/application/internal/dto/CategoryInternalResult.java
+++ b/src/main/java/com/lxp/aplus/category/application/internal/dto/CategoryInternalResult.java
@@ -4,21 +4,26 @@ import com.lxp.aplus.category.domain.Category;
 import lombok.Builder;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Builder
 public record CategoryInternalResult(
         Long id,
         String name,
-        Category parent,
-        List<Category> children
+        String parentName,
+        List<Long> childrenIds
 ) {
         public static CategoryInternalResult from(Category category) {
+            String parentName = category.getParent() != null ? category.getParent().getName() : null;
+            List<Long> childrenIds = category.getChildren().stream()
+                    .map(Category::getId)
+                    .collect(Collectors.toList());
 
             return CategoryInternalResult.builder()
                     .id(category.getId())
                     .name(category.getName())
-                    .parent(category.getParent())
-                    .children(category.getChildren())
+                    .parentName(parentName)
+                    .childrenIds(childrenIds)
                     .build();
         }
 }

--- a/src/main/java/com/lxp/aplus/enrollment/application/result/EnrollmentDetailResult.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/result/EnrollmentDetailResult.java
@@ -10,17 +10,17 @@ public record EnrollmentDetailResult(
         Long studentId,
         Long courseId,
         EnrollmentStatus status,
-        int progressRate,
+        int overallProgressRate,
         LocalDateTime createdAt,
         LocalDateTime expiredAt
 ) {
-    public static EnrollmentDetailResult of(Enrollment enrollment, int progressRate) {
+    public static EnrollmentDetailResult of(Enrollment enrollment, int overallProgressRate) {
         return new EnrollmentDetailResult(
                 enrollment.getId(),
                 enrollment.getStudentId(),
                 enrollment.getCourseId(),
                 enrollment.getStatus(),
-                progressRate,
+                overallProgressRate,
                 enrollment.getCreatedAt(),
                 enrollment.getExpiredAt()
         );

--- a/src/main/java/com/lxp/aplus/enrollment/application/result/EnrollmentListItemResult.java
+++ b/src/main/java/com/lxp/aplus/enrollment/application/result/EnrollmentListItemResult.java
@@ -15,17 +15,17 @@ public record EnrollmentListItemResult(
         String courseName,
         List<String> categories,
         EnrollmentStatus status,
-        int progressRate,
+        int overallProgressRate,
         LocalDateTime expiredAt
 ) {
-    public static EnrollmentListItemResult of(Enrollment enrollment, CourseSummary courseSummary, int progressRate, List<String> categories) {
+    public static EnrollmentListItemResult of(Enrollment enrollment, CourseSummary courseSummary, int overallProgressRate, List<String> categories) {
         return new EnrollmentListItemResult(
                 enrollment.getId(),
                 enrollment.getCourseId(),
                 courseSummary.courseName(),
                 categories,
                 enrollment.getStatus(),
-                progressRate,
+                overallProgressRate,
                 enrollment.getExpiredAt()
         );
     }

--- a/src/main/java/com/lxp/aplus/enrollment/infrastructure/adapter/module/CourseModuleAdapter.java
+++ b/src/main/java/com/lxp/aplus/enrollment/infrastructure/adapter/module/CourseModuleAdapter.java
@@ -12,9 +12,9 @@ import java.util.List;
 import java.util.Optional;
 
 
-@Component("enrollmentCourseQueryPortAdapter")
+@Component("enrollmentCourseModuleAdapter")
 @RequiredArgsConstructor
-public class CourseQueryPortAdapter implements CourseQueryPort {
+public class CourseModuleAdapter implements CourseQueryPort {
 
     private final CourseInternalUseCase courseInternalUseCase;
     private final CategoryInternalUseCase categoryInternalUseCase;

--- a/src/main/java/com/lxp/aplus/enrollment/infrastructure/adapter/module/CourseQueryPortAdapter.java
+++ b/src/main/java/com/lxp/aplus/enrollment/infrastructure/adapter/module/CourseQueryPortAdapter.java
@@ -1,14 +1,12 @@
 package com.lxp.aplus.enrollment.infrastructure.adapter.module;
 
 import com.lxp.aplus.category.application.internal.usecase.CategoryInternalUseCase;
-import com.lxp.aplus.category.domain.Category;
 import com.lxp.aplus.course.application.internal.usecase.CourseInternalUseCase;
 import com.lxp.aplus.enrollment.application.port.out.CourseQueryPort;
 import com.lxp.aplus.enrollment.application.port.out.CourseSummary;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -38,18 +36,12 @@ public class CourseQueryPortAdapter implements CourseQueryPort {
                 .map(course -> course.categoryId())
                 .filter(categoryId -> categoryId != null)
                 .flatMap(categoryInternalUseCase::findByIdWithParent)
-                .map(category -> buildCategoryNames(category.name(), category.parent()))
+                .map(category -> {
+                    if (category.parentName() == null) {
+                        return List.of(category.name());
+                    }
+                    return List.of(category.parentName(), category.name());
+                })
                 .orElse(Collections.emptyList());
-    }
-
-    private List<String> buildCategoryNames(String leafName, Category parent) {
-        List<String> names = new ArrayList<>();
-        names.add(leafName);
-        var current = parent;
-        while (current != null) {
-            names.add(0, current.getName());
-            current = current.getParent();
-        }
-        return names;
     }
 }

--- a/src/main/java/com/lxp/aplus/enrollment/presentation/response/EnrollmentDetailResponse.java
+++ b/src/main/java/com/lxp/aplus/enrollment/presentation/response/EnrollmentDetailResponse.java
@@ -9,7 +9,7 @@ public record EnrollmentDetailResponse(
         Long studentId,
         Long courseId,
         EnrollmentStatus status,
-        int progressRate,
+        int overallProgressRate,
         LocalDateTime createdAt,
         LocalDateTime expiredAt
 ) {
@@ -19,7 +19,7 @@ public record EnrollmentDetailResponse(
                 result.studentId(),
                 result.courseId(),
                 result.status(),
-                result.progressRate(),
+                result.overallProgressRate(),
                 result.createdAt(),
                 result.expiredAt()
         );

--- a/src/test/java/com/lxp/aplus/enrollment/application/service/EnrollmentQueryServiceTest.java
+++ b/src/test/java/com/lxp/aplus/enrollment/application/service/EnrollmentQueryServiceTest.java
@@ -91,12 +91,12 @@ class EnrollmentQueryServiceTest {
 
         EnrollmentListItemResult result1 = result.getContent().get(0);
         assertThat(result1.courseId()).isEqualTo(COURSE_ID_1);
-        assertThat(result1.progressRate()).isEqualTo(40);
+        assertThat(result1.overallProgressRate()).isEqualTo(40);
         assertThat(result1.categories()).containsExactly("프로그래밍", "백엔드");
 
         EnrollmentListItemResult result2 = result.getContent().get(1);
         assertThat(result2.courseId()).isEqualTo(COURSE_ID_2);
-        assertThat(result2.progressRate()).isEqualTo(35);
+        assertThat(result2.overallProgressRate()).isEqualTo(35);
         assertThat(result2.categories()).containsExactly("프로그래밍", "프론트엔드");
     }
 
@@ -154,7 +154,7 @@ class EnrollmentQueryServiceTest {
         assertThat(result.enrollmentId()).isEqualTo(enrollmentId);
         assertThat(result.studentId()).isEqualTo(studentId);
         assertThat(result.courseId()).isEqualTo(courseId);
-        assertThat(result.progressRate()).isEqualTo(40);
+        assertThat(result.overallProgressRate()).isEqualTo(40);
         assertThat(result.status()).isEqualTo(EnrollmentStatus.ENROLLED);
     }
 
@@ -214,7 +214,7 @@ class EnrollmentQueryServiceTest {
         assertThat(result.enrollmentId()).isEqualTo(enrollmentId);
         assertThat(result.studentId()).isEqualTo(studentId);
         assertThat(result.courseId()).isEqualTo(courseId);
-        assertThat(result.progressRate()).isEqualTo(40);
+        assertThat(result.overallProgressRate()).isEqualTo(40);
         assertThat(result.status()).isEqualTo(EnrollmentStatus.ENROLLED);
     }
 


### PR DESCRIPTION
## ✨ 요약
  - 수강 목록/상세 응답의 progressRate를 overallProgressRate로 변경
  - 카테고리 내부 DTO를 parentName/childrenIds로 정리해 도메인 의존성 완화

## 📝 작업 내용
EnrollmentListItemResult, EnrollmentDetailResult, EnrollmentDetailResponse 필드명 변경
카테고리 CategoryInternalResult를 parentName/childrenIds로 정리 후 CourseQueryPortAdapter여기서 category 의존성 제거

## 💭 주의 사항

## 💡 리뷰 포인트
호준님과 상의후 변경. 호준님께 공유했습니다. 맞는지 호준님도 리뷰 부탁드립니다.

## ✅ 테스트
- [x] 로컬 빌드/실행
- [x] 단위 테스트 추가/통과
- [x] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
<img width="880" height="444" alt="image" src="https://github.com/user-attachments/assets/d0b3c2e9-94aa-4bae-b35a-0f884480bdb5" />
<img width="880" height="444" alt="image" src="https://github.com/user-attachments/assets/164bf4ca-7d9e-4a23-a791-a230f97d7cce" />
<img width="880" height="444" alt="image" src="https://github.com/user-attachments/assets/68135d3f-cdec-4d76-8dc5-39a1f3130b40" />
<img width="880" height="444" alt="image" src="https://github.com/user-attachments/assets/ee2cd366-d249-4bde-8156-dc24128ea9ed" />
<img width="880" height="444" alt="image" src="https://github.com/user-attachments/assets/f75bb30f-667d-4b29-88a8-365ee05e4b3b" />
<img width="880" height="444" alt="image" src="https://github.com/user-attachments/assets/26da604d-48e3-452c-960c-a8c4a4615e50" />
