### PR TITLE
[FIX] 강좌 생성시에 섬네일 키 받도록 수정

### DIFF
--- a/src/main/java/com/lxp/aplus/course/application/command/CourseCreateCommand.java
+++ b/src/main/java/com/lxp/aplus/course/application/command/CourseCreateCommand.java
@@ -12,7 +12,6 @@ public record CourseCreateCommand(
         Long categoryId,
         int price,
         String thumbnailUrl,
-        MultipartFile thumbnailFile,
         CourseLevel courseLevel,
         String thumbnailResourceKey
 ) {

--- a/src/main/java/com/lxp/aplus/course/presentation/request/CourseCreateRequest.java
+++ b/src/main/java/com/lxp/aplus/course/presentation/request/CourseCreateRequest.java
@@ -11,7 +11,8 @@ public record CourseCreateRequest(@NotBlank(message = "제목은 필수입니다
                                   @NotBlank(message = "한 줄 요약은 필수입니다.") String summary,
                                   @NotBlank(message = "상세 설명은 필수입니다.") String description,
                                   @NotNull(message = "가격은 필수입니다.") @Min(value = 0, message = "가격은 0원 이상이어야 합니다.") int price,
-                                  @NotNull(message = "난이도는 필수입니다.") CourseLevel courseLevel
+                                  @NotNull(message = "난이도는 필수입니다.") CourseLevel courseLevel,
+                                  @NotBlank(message = "썸네일 리소스 키는 필수입니다.") String thumbnailResourceKey
 ) {
     public CourseCreateCommand toCommand() {
         return CourseCreateCommand.builder()
@@ -21,7 +22,7 @@ public record CourseCreateRequest(@NotBlank(message = "제목은 필수입니다
                 .categoryId(this.categoryId)
                 .courseLevel(this.courseLevel)
                 .price(this.price)
-                .thumbnailFile(null) // TODO: 썸네일 리소스 key 발급 로직 필요
+                .thumbnailResourceKey(this.thumbnailResourceKey)
                 .build();
     }
 }


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ✨ 요약
강좌 생성시에 섬네일 키 받도록 수정

## 📝 작업 내용
강좌 생성시에 섬네일 키 (thumbnailResourceKey) 받도록 수정했습니다.

## 💭 주의 사항

## 💡 리뷰 포인트

## ✅ 테스트
- [x] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [x] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
