### PR TITLE
[FIX] 강좌 상세 조회 시에 섬네일 URL 잘못 들고 오는 문제 해결

### DIFF
--- a/src/main/java/com/lxp/aplus/course/application/mapper/CourseResultMapper.java
+++ b/src/main/java/com/lxp/aplus/course/application/mapper/CourseResultMapper.java
@@ -14,9 +14,7 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 public class CourseResultMapper {
-
     private final SectionResultMapper sectionResultMapper;
-    private final FileUrlGenerator fileUrlGenerator;
 
     public CourseResult toResult(Course course, List<String> categoryNames, String instructorName, int studentCount, ReviewStat reviewStat) {
         return CourseResult.builder()
@@ -46,7 +44,7 @@ public class CourseResultMapper {
                 .price(course.getPrice())
                 .status(course.getCourseStatus())
                 .level(course.getCourseLevel())
-                .thumbnailUrl(course.getThumbnailResourceKey() != null ? fileUrlGenerator.generate(course.getThumbnailResourceKey()) : null)
+                .thumbnailUrl(course.getThumbnailResourceKey())
                 .instructor(instructor)
                 .isPurchased(isPurchased)
                 .studentCount(studentCount)


### PR DESCRIPTION
<!-- PR 제목 : [Commit Type] PR_내용 -->
<!-- PR 내용의 경우, 이슈 제목을 그대로 써도 되고, 이슈에 언급되지 않은 내용까지 써주세용 -->
<!-- ex) [FEAT] 회원 API 구현 -->

## ✨ 요약
강좌 상세 조회 시에 섬네일 URL 잘못 들고 오는 문제 해결

## 📝 작업 내용
강좌 상세 조회 시에 섬네일 URL 잘못 들고 오는 문제 해결했습니다.

## 💭 주의 사항

## 💡 리뷰 포인트

## ✅ 테스트
- [ ] 로컬 빌드/실행
- [ ] 단위 테스트 추가/통과
- [ ] API 수동 테스트

## 📸 참고(스크린샷 / API 예시)
